### PR TITLE
fix: client generating it's own date for events

### DIFF
--- a/src/lib/dtos.ts
+++ b/src/lib/dtos.ts
@@ -34,6 +34,7 @@ export type MapGuessResponse = {
 
 export type WeaponGuessResponse = {
 	correct: boolean;
+	guessedAt: string;
 	name: string;
 	numberOfCorrectGuesses: number;
 	releaseDate: {

--- a/src/lib/dtos.ts
+++ b/src/lib/dtos.ts
@@ -68,6 +68,7 @@ export type CosmeticGuessResponse = {
 	name: string;
 	thumbnail: string;
 	correct: boolean;
+	guessedAt: string;
 	usedBy?: string;
 };
 

--- a/src/lib/dtos.ts
+++ b/src/lib/dtos.ts
@@ -16,6 +16,7 @@ export type MapDto = {
 
 export type MapGuessResponse = {
 	correct: boolean;
+	guessedAt: string;
 	name: {
 		status: 'correct' | 'incorrect';
 		value: string;

--- a/src/lib/patchNotes/index.ts
+++ b/src/lib/patchNotes/index.ts
@@ -3,7 +3,8 @@ import patch_0_2 from './patch_0_2';
 import patch_1_0 from './patch_1_0';
 import patch_1_1 from './patch_1_1';
 import patch_1_2 from './patch_1_2';
+import patch_1_3 from './patch_1_3';
 
-const patchNotes = [patch_1_2, patch_1_1, patch_1_0, patch_0_2, patch_0_1];
+const patchNotes = [patch_1_3, patch_1_2, patch_1_1, patch_1_0, patch_0_2, patch_0_1];
 
 export default patchNotes;

--- a/src/lib/patchNotes/patch_1_3.ts
+++ b/src/lib/patchNotes/patch_1_3.ts
@@ -1,0 +1,20 @@
+export default {
+	version: '1.3',
+	date: '',
+	newFeatures: [],
+	improvements: [],
+	bugFixes: [
+		{
+			title: 'Timing bug',
+			description:
+				'If you guessed correct some seconds before midnight, the server would validate it to correct, and if by the time it reached the client, a new day had started, it would be marked as if you had guessed the new days puzzle. This has been fixed and should no longer be an issue',
+			gameMode: 'all'
+		},
+		{
+			title: 'Cosmetic color show when correct',
+			description:
+				'Previously, the color of the cosmetic would not be shown when you guessed it correctly prior to the hint. This has been fixed and the color will now be shown when you guess the cosmetic correctly.',
+			gameMode: 'cosmetics'
+		}
+	]
+};

--- a/src/lib/patchNotes/patch_1_3.ts
+++ b/src/lib/patchNotes/patch_1_3.ts
@@ -1,6 +1,6 @@
 export default {
 	version: '1.3',
-	date: '',
+	date: '14.02.2024',
 	newFeatures: [],
 	improvements: [],
 	bugFixes: [
@@ -13,7 +13,7 @@ export default {
 		{
 			title: 'Cosmetic color show when correct',
 			description:
-				'Previously, the color of the cosmetic would not be shown when you guessed it correctly prior to the hint. This has been fixed and the color will now be shown when you guess the cosmetic correctly.',
+				"Previously, the gray filter of the cosmetic would still be applied when you guessed correct cosmetic prior to the color hint. This has been fixed and the gray filter will now be removed whenever you guess the correct cosmetic, regardless if it's prior to the color hint or not.",
 			gameMode: 'cosmetics'
 		}
 	]

--- a/src/lib/server/repositories/CosmeticRepository.ts
+++ b/src/lib/server/repositories/CosmeticRepository.ts
@@ -18,7 +18,8 @@ export interface CosmeticRepository {
 	saveTodaysCosmetic(cosmetic: Cosmetic, rotation: number): Promise<DailyCosmetics>;
 
 	/**
-	 * Increments the number of correct guesses for the selected cosmetic of the current day
+	 * Increments the number of correct guesses for a given cosmetic
+	 * @param date of the selected cosmetic to increment
 	 */
-	incrementNumberOfCorrectGuesses(): Promise<void>;
+	incrementNumberOfCorrectGuesses(date: Dayjs): Promise<void>;
 }

--- a/src/lib/server/repositories/CosmeticRepository.ts
+++ b/src/lib/server/repositories/CosmeticRepository.ts
@@ -1,11 +1,14 @@
 import type { Cosmetic } from '$lib/types';
 import type { DailyCosmetics } from '@prisma/client';
+import type { Dayjs } from 'dayjs';
 
 export interface CosmeticRepository {
 	/**
-	 * Finds the cosmetic that is selected for the current day
+	 * Finds the cosmetic that is selected for the given date
+	 * @param date the date to get the cosmetic for
+	 * @return the selected cosmetic
 	 */
-	findTodaysCosmetic(): Promise<DailyCosmetics | null>;
+	findCosmetic(date: Dayjs): Promise<DailyCosmetics | null>;
 
 	/**
 	 * Saves a cosmetic as the selected cosmetic for the current day

--- a/src/lib/server/repositories/CosmeticRepositoryPrisma.ts
+++ b/src/lib/server/repositories/CosmeticRepositoryPrisma.ts
@@ -25,10 +25,10 @@ class CosmeticRepositoryPrisma implements CosmeticRepository {
 		});
 	}
 
-	public async incrementNumberOfCorrectGuesses() {
+	public async incrementNumberOfCorrectGuesses(date: Dayjs) {
 		await db.dailyCosmetics.updateMany({
 			where: {
-				selectedAt: dayjs.utc().toDate()
+				selectedAt: date.toDate()
 			},
 			data: {
 				hasWon: {

--- a/src/lib/server/repositories/CosmeticRepositoryPrisma.ts
+++ b/src/lib/server/repositories/CosmeticRepositoryPrisma.ts
@@ -1,13 +1,14 @@
 import dayjs from '$lib/configs/dayjsConfig';
 import type { Cosmetic } from '$lib/types';
+import type { Dayjs } from 'dayjs';
 import { db } from '../prisma';
 import type { CosmeticRepository } from './CosmeticRepository';
 
 class CosmeticRepositoryPrisma implements CosmeticRepository {
-	public async findTodaysCosmetic() {
+	public async findCosmetic(date: Dayjs) {
 		return await db.dailyCosmetics.findFirst({
 			where: {
-				selectedAt: dayjs.utc().toDate()
+				selectedAt: date.toDate()
 			}
 		});
 	}

--- a/src/lib/server/repositories/MapRepository.ts
+++ b/src/lib/server/repositories/MapRepository.ts
@@ -1,4 +1,5 @@
 import type { DailyMaps } from '@prisma/client';
+import type { Dayjs } from 'dayjs';
 
 export interface MapRepository {
 	/**
@@ -15,6 +16,12 @@ export interface MapRepository {
 	 * Returns the name of todays map
 	 */
 	getTodaysMap(): Promise<DailyMaps | null>;
+
+	/**
+	 * Returns the map that was selected for the given time
+	 * @param time time to get the map for
+	 */
+	getMap(date: Dayjs): Promise<DailyMaps | null>;
 
 	/**
 	 * Increments the number of correct guesses for todays map

--- a/src/lib/server/repositories/MapRepository.ts
+++ b/src/lib/server/repositories/MapRepository.ts
@@ -24,7 +24,8 @@ export interface MapRepository {
 	getMap(date: Dayjs): Promise<DailyMaps | null>;
 
 	/**
-	 * Increments the number of correct guesses for todays map
+	 * Increments the number of correct guesses for a map
+	 * @param date date of the selected map to increment
 	 */
-	incrementTodaysNumberOfCorrectGuesses(): Promise<void>;
+	incrementTodaysNumberOfCorrectGuesses(date: Dayjs): Promise<void>;
 }

--- a/src/lib/server/repositories/MapRepositoryPrisma.ts
+++ b/src/lib/server/repositories/MapRepositoryPrisma.ts
@@ -31,10 +31,10 @@ class MapRepositoryPrisma implements MapRepository {
 		});
 	}
 
-	public async incrementTodaysNumberOfCorrectGuesses() {
+	public async incrementTodaysNumberOfCorrectGuesses(date: Dayjs) {
 		await db.dailyMaps.updateMany({
 			where: {
-				selectedAt: dayjs.utc().toDate()
+				selectedAt: date.toDate()
 			},
 			data: {
 				hasWon: {

--- a/src/lib/server/repositories/MapRepositoryPrisma.ts
+++ b/src/lib/server/repositories/MapRepositoryPrisma.ts
@@ -1,4 +1,5 @@
 import dayjs from '$lib/configs/dayjsConfig';
+import type { Dayjs } from 'dayjs';
 import { db } from '../prisma';
 import type { MapRepository } from './MapRepository';
 
@@ -18,6 +19,14 @@ class MapRepositoryPrisma implements MapRepository {
 		return await db.dailyMaps.findFirst({
 			where: {
 				selectedAt: dayjs.utc().toDate()
+			}
+		});
+	}
+
+	public async getMap(date: Dayjs) {
+		return await db.dailyMaps.findFirst({
+			where: {
+				selectedAt: date.toDate()
 			}
 		});
 	}

--- a/src/lib/server/repositories/WeaponRepository.ts
+++ b/src/lib/server/repositories/WeaponRepository.ts
@@ -1,10 +1,13 @@
 import type { Weapon } from '$lib/types';
+import type { Dayjs } from 'dayjs';
 
 export interface WeaponRepository {
 	/**
-	 * Returns the name of todays weapon
+	 * Returns the name of weapon selected for the given date
+	 * @param date the date to get the weapon for
+	 * @returns the name of the weapon selected for the given date
 	 */
-	getTodaysWeapon(): Promise<string | null>;
+	getWeapon(date: Dayjs): Promise<string | null>;
 
 	/**
 	 * Saves a weapon as the selected weapon for the current day

--- a/src/lib/server/repositories/WeaponRepository.ts
+++ b/src/lib/server/repositories/WeaponRepository.ts
@@ -21,7 +21,8 @@ export interface WeaponRepository {
 	getNumberOfCorrectGuesses(): Promise<number>;
 
 	/**
-	 * Increments the number of correct guesses for the selected weapon of the current day
+	 * Increments the number of correct guesses for a given weapon
+	 * @param date of the selected weapon to increment
 	 */
-	incrementNumberOfCorrectGuesses(): Promise<void>;
+	incrementNumberOfCorrectGuesses(date: Dayjs): Promise<void>;
 }

--- a/src/lib/server/repositories/WeaponRepositoryPrisma.ts
+++ b/src/lib/server/repositories/WeaponRepositoryPrisma.ts
@@ -5,10 +5,10 @@ import { db } from '../prisma';
 import type { WeaponRepository } from './WeaponRepository';
 
 class WeaponRepositoryPrisma implements WeaponRepository {
-	async incrementNumberOfCorrectGuesses(): Promise<void> {
+	async incrementNumberOfCorrectGuesses(date: Dayjs): Promise<void> {
 		await db.dailyWeapons.updateMany({
 			where: {
-				selectedAt: dayjs.utc().toDate()
+				selectedAt: date.toDate()
 			},
 			data: {
 				hasWon: {

--- a/src/lib/server/repositories/WeaponRepositoryPrisma.ts
+++ b/src/lib/server/repositories/WeaponRepositoryPrisma.ts
@@ -1,5 +1,6 @@
 import dayjs from '$lib/configs/dayjsConfig';
 import type { Weapon } from '$lib/types';
+import type { Dayjs } from 'dayjs';
 import { db } from '../prisma';
 import type { WeaponRepository } from './WeaponRepository';
 
@@ -27,10 +28,10 @@ class WeaponRepositoryPrisma implements WeaponRepository {
 			.then((weapon) => weapon?.hasWon ?? 0);
 	}
 
-	async getTodaysWeapon(): Promise<string | null> {
+	async getWeapon(date: Dayjs): Promise<string | null> {
 		const weapon = await db.dailyWeapons.findFirst({
 			where: {
-				selectedAt: dayjs.utc().toDate()
+				selectedAt: date.toDate()
 			}
 		});
 

--- a/src/lib/server/services/CosmeticService.ts
+++ b/src/lib/server/services/CosmeticService.ts
@@ -78,7 +78,7 @@ class CosmeticService {
 		const correct = guess === todaysCosmetic.name;
 
 		if (correct) {
-			await this.repo.incrementNumberOfCorrectGuesses();
+			await this.repo.incrementNumberOfCorrectGuesses(currentTime);
 		}
 
 		return {

--- a/src/lib/server/services/CosmeticService.ts
+++ b/src/lib/server/services/CosmeticService.ts
@@ -2,8 +2,9 @@ import type { Cosmetic } from '$lib/types';
 import cosmetics from '$lib/server/data/cosmetics.json';
 import type { CosmeticRepository } from '$lib/server/repositories/CosmeticRepository';
 import { cosmeticRepository } from '$lib/server/repositories/CosmeticRepositoryPrisma';
-import type { CosmeticGuessResponse } from '$lib/dtos';
 import LogService from './LogService';
+import dayjs from '$lib/configs/dayjsConfig';
+import type { Dayjs } from 'dayjs';
 
 /**
  * Service for handling cosmetics
@@ -26,11 +27,12 @@ class CosmeticService {
 	}
 
 	/**
-	 * Returns the cosmetic that is selected for the current day
+	 * Returns the cosmetic that is selected for the given date
+	 * @param date the date to get the cosmetic for
 	 * @returns cosmetic for the current day
 	 */
-	public async getTodaysCosmetic() {
-		let cosmetic = await this.repo.findTodaysCosmetic();
+	public async getCosmetic(date: Dayjs) {
+		let cosmetic = await this.repo.findCosmetic(date);
 
 		if (!cosmetic) {
 			cosmetic = await this.selectRandomCosmetic();
@@ -63,7 +65,9 @@ class CosmeticService {
 	 * A hint is provided if the user has made 9 or more guesses
 	 */
 	public async validateGuess(guess: string, numberOfGuesses: number) {
-		const todaysCosmetic = await this.getTodaysCosmetic();
+		const currentTime = dayjs.utc();
+
+		const todaysCosmetic = await this.getCosmetic(currentTime);
 		const guessedCosmetic = this.cosmetics.find((cosmetic) => cosmetic.name === guess);
 
 		let usedBy: string | undefined;
@@ -81,6 +85,7 @@ class CosmeticService {
 			name: guessedCosmetic?.name ?? '',
 			thumbnail: guessedCosmetic?.image ?? '',
 			correct: correct,
+			guessedAt: currentTime.format(),
 			usedBy
 		};
 	}

--- a/src/lib/server/services/MapService.ts
+++ b/src/lib/server/services/MapService.ts
@@ -55,7 +55,7 @@ class MapService {
 		};
 	}
 
-	private async getMapBasedOnTime(date: Dayjs) {
+	private async getMap(date: Dayjs) {
 		const savedMap = await this.repo.getMap(date);
 
 		return this.maps.find((map) => map.name === savedMap?.name);
@@ -71,7 +71,7 @@ class MapService {
 	public async validateGuess(guess: string) {
 		const currentTime = dayjs.utc();
 
-		const todaysMap = await this.getMapBasedOnTime(currentTime);
+		const todaysMap = await this.getMap(currentTime);
 		const guessedMap = this.maps.find((map) => map.name.toLowerCase() === guess.toLowerCase());
 
 		const correct = guessedMap?.name === todaysMap?.name;

--- a/src/lib/server/services/MapService.ts
+++ b/src/lib/server/services/MapService.ts
@@ -101,7 +101,7 @@ class MapService {
 		const releaseDateValue = dayjs(guessedMap?.releaseDate).year() ?? '';
 
 		if (correct) {
-			await this.repo.incrementTodaysNumberOfCorrectGuesses();
+			await this.repo.incrementTodaysNumberOfCorrectGuesses(currentTime);
 		}
 
 		return {

--- a/src/lib/server/services/MapService.ts
+++ b/src/lib/server/services/MapService.ts
@@ -56,7 +56,11 @@ class MapService {
 	}
 
 	private async getMap(date: Dayjs) {
-		const savedMap = await this.repo.getMap(date);
+		let savedMap = await this.repo.getMap(date);
+
+		if (!savedMap) {
+			savedMap = await this.selectRandomMap();
+		}
 
 		return this.maps.find((map) => map.name === savedMap?.name);
 	}

--- a/src/lib/server/services/MapService.ts
+++ b/src/lib/server/services/MapService.ts
@@ -4,6 +4,7 @@ import dayjs from '$lib/configs/dayjsConfig';
 import type { MapRepository } from '../repositories/MapRepository';
 import { mapRepository } from '../repositories/MapRepositoryPrisma';
 import LogService from './LogService';
+import type { Dayjs } from 'dayjs';
 
 class MapService {
 	private maps: Map[];
@@ -54,6 +55,12 @@ class MapService {
 		};
 	}
 
+	private async getMapBasedOnTime(date: Dayjs) {
+		const savedMap = await this.repo.getMap(date);
+
+		return this.maps.find((map) => map.name === savedMap?.name);
+	}
+
 	/**
 	 * Validates a map guess
 	 * @param guess name of the map guessed
@@ -62,8 +69,9 @@ class MapService {
 	 * the hint of the guessed game matches the hint of the correct game
 	 */
 	public async validateGuess(guess: string) {
-		const todaysSavedMap = await this.getTodaysMap();
-		const todaysMap = this.maps.find((map) => map.name === todaysSavedMap.name);
+		const currentTime = dayjs.utc();
+
+		const todaysMap = await this.getMapBasedOnTime(currentTime);
 		const guessedMap = this.maps.find((map) => map.name.toLowerCase() === guess.toLowerCase());
 
 		const correct = guessedMap?.name === todaysMap?.name;
@@ -98,6 +106,7 @@ class MapService {
 
 		return {
 			correct,
+			guessedAt: currentTime.format(),
 			name: {
 				status: nameStatus,
 				value: nameValue

--- a/src/lib/server/services/WeaponService.ts
+++ b/src/lib/server/services/WeaponService.ts
@@ -3,6 +3,8 @@ import type { Weapon } from '$lib/types';
 import { weaponRepository } from '$lib/server/repositories/WeaponRepositoryPrisma';
 import type { WeaponRepository } from '$lib/server/repositories/WeaponRepository';
 import LogService from './LogService';
+import dayjs from '$lib/configs/dayjsConfig';
+import type { Dayjs } from 'dayjs';
 
 class WeaponService {
 	private weapons: Weapon[];
@@ -76,7 +78,9 @@ class WeaponService {
 	 * @returns a WeaponGuessResponse object
 	 */
 	public async validateGuess(guess: string) {
-		const todaysWeapon = await this.getTodaysWeapon();
+		const currnetTime = dayjs.utc();
+
+		const todaysWeapon = await this.getWeapon(currnetTime);
 		const guessedWeapon = this.weapons.find((w) => w.name === guess);
 
 		if (!guessedWeapon || !todaysWeapon) {
@@ -152,6 +156,7 @@ class WeaponService {
 
 		return {
 			correct,
+			guessedAt: currnetTime.format(),
 			name: guess,
 			numberOfCorrectGuesses: await this.repo.getNumberOfCorrectGuesses(),
 			releaseDate: {
@@ -178,11 +183,12 @@ class WeaponService {
 	}
 
 	/**
-	 * Returns todays weapon
+	 * Returns the selected weapon for a given date
+	 * @param date to get weapon for
 	 * @returns name of todays weapon
 	 */
-	private async getTodaysWeapon() {
-		let weapon = await this.repo.getTodaysWeapon();
+	private async getWeapon(date: Dayjs) {
+		let weapon = await this.repo.getWeapon(date);
 
 		if (!weapon) {
 			weapon = await this.selectNewRandomWeapon();

--- a/src/lib/server/services/WeaponService.ts
+++ b/src/lib/server/services/WeaponService.ts
@@ -78,9 +78,9 @@ class WeaponService {
 	 * @returns a WeaponGuessResponse object
 	 */
 	public async validateGuess(guess: string) {
-		const currnetTime = dayjs.utc();
+		const currentTime = dayjs.utc();
 
-		const todaysWeapon = await this.getWeapon(currnetTime);
+		const todaysWeapon = await this.getWeapon(currentTime);
 		const guessedWeapon = this.weapons.find((w) => w.name === guess);
 
 		if (!guessedWeapon || !todaysWeapon) {
@@ -91,7 +91,7 @@ class WeaponService {
 		const correct = todaysWeapon.name === guess;
 
 		if (correct) {
-			await this.repo.incrementNumberOfCorrectGuesses();
+			await this.repo.incrementNumberOfCorrectGuesses(currentTime);
 		}
 
 		// Validate release year
@@ -156,7 +156,7 @@ class WeaponService {
 
 		return {
 			correct,
-			guessedAt: currnetTime.format(),
+			guessedAt: currentTime.format(),
 			name: guess,
 			numberOfCorrectGuesses: await this.repo.getNumberOfCorrectGuesses(),
 			releaseDate: {

--- a/src/routes/api/v1/game-modes/cosmetic/+server.ts
+++ b/src/routes/api/v1/game-modes/cosmetic/+server.ts
@@ -1,3 +1,4 @@
+import dayjs from '$lib/configs/dayjsConfig';
 import { cosmeticService } from '$lib/server/services/CosmeticService';
 import { json } from '@sveltejs/kit';
 
@@ -7,7 +8,8 @@ import { json } from '@sveltejs/kit';
  * @returns HttpResponse
  */
 export async function GET() {
-	const todaysCosmetic = await cosmeticService.getTodaysCosmetic();
+	const currentTime = dayjs.utc();
+	const todaysCosmetic = await cosmeticService.getCosmetic(currentTime);
 
 	return json({
 		cosmetic: {

--- a/src/routes/game-modes/cosmetic/+page.svelte
+++ b/src/routes/game-modes/cosmetic/+page.svelte
@@ -91,15 +91,14 @@
 	async function handleSelect(name: string) {
 		if (gameState === 'won') return;
 
-		// Update last event
-		lastEvent.set({ event: 'guessed', date: dayjs.utc().format() });
-
 		// Validate guess
 		const result = await checkGuess(name);
 
 		// Update game state based on result
 		if (result) {
 			guesses.update((guesses) => [result, ...guesses]);
+			// Update last event
+			lastEvent.set({ event: result.correct ? 'won' : 'guessed', date: result.guessedAt });
 			if (result.usedBy) {
 				usedBy.set(result.usedBy);
 			}
@@ -151,7 +150,6 @@
 	 */
 	function won() {
 		setTimeout(() => {
-			lastEvent.set({ event: 'won', date: dayjs.utc().format() });
 			streak.update((streak) => streak + 1);
 			numberOfCorrectGuesses = numberOfCorrectGuesses ? numberOfCorrectGuesses + 1 : 1;
 			gameState = 'won';

--- a/src/routes/game-modes/cosmetic/CosmeticShowcase.svelte
+++ b/src/routes/game-modes/cosmetic/CosmeticShowcase.svelte
@@ -49,6 +49,7 @@
 
 		if (hasWon) {
 			wrapper.style.transform = `rotate(0deg)`;
+			wrapper.style.filter = 'grayscale(0)';
 			ctx.filter = 'grayscale(0)';
 			ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
 		} else {

--- a/src/routes/game-modes/map/+page.svelte
+++ b/src/routes/game-modes/map/+page.svelte
@@ -77,19 +77,18 @@
 	async function handleSelect(name: string) {
 		if (gameState === 'won') return;
 
-		// Update last event
-		lastEvent.set({ event: 'guessed', date: dayjs.utc().format() });
-
 		// Validate guess
 		const result = await checkGuess(name);
 
-		// Update game state based on result
 		if (result) {
+			// Update guesses list
 			guesses.update((guesses) => [result, ...guesses]);
-		}
+			// Update last event
+			lastEvent.set({ event: result.correct ? 'won' : 'guessed', date: result.guessedAt });
 
-		if (result?.correct) {
-			won(result.name.value);
+			if (result.correct) {
+				won(result.name.value);
+			}
 		}
 	}
 
@@ -134,7 +133,6 @@
 	function won(mapName: string) {
 		// Wait for reveal animation to finish
 		setTimeout(() => {
-			lastEvent.set({ event: 'won', date: dayjs.utc().format() });
 			streak.update((streak) => streak + 1);
 			todaysMapName = mapName;
 			numberOfCorrectGuesses = numberOfCorrectGuesses ? numberOfCorrectGuesses + 1 : 1;

--- a/src/routes/game-modes/weapon/+page.svelte
+++ b/src/routes/game-modes/weapon/+page.svelte
@@ -84,15 +84,14 @@
 	async function handleGuess(guess: string) {
 		if (gameState === 'won') return;
 
-		// Update last event
-		lastEvent.set({ event: 'guessed', date: dayjs.utc().format() });
-
 		// Validate guess
 		const result = await checkGuess(guess);
 
 		// Update game state based on result
 		if (result) {
 			guesses.update((guesses) => [result, ...guesses]);
+			// Update last event
+			lastEvent.set({ event: result.correct ? 'won' : 'guessed', date: result.guessedAt });
 		}
 
 		if (result?.correct) {
@@ -137,7 +136,6 @@
 	function won() {
 		// Wait for reveal animation to finish
 		setTimeout(() => {
-			lastEvent.set({ event: 'won', date: dayjs.utc().format() });
 			streak.update((streak) => streak + 1);
 			gameState = 'won';
 			numberOfCorrectGuesses = numberOfCorrectGuesses ? numberOfCorrectGuesses + 1 : 1;


### PR DESCRIPTION
Client was generating its own dates for events when it should have gotten this from the server based on when the server validated the guesses. This is now fixed.