### PR TITLE
Hide name, update random selector, update patch notes design

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"lucide-svelte": "^0.314.0",
 		"mode-watcher": "^0.1.2",
 		"node-schedule": "^2.1.1",
+		"oslo": "^1.2.1",
 		"svelte-sonner": "^0.3.11",
 		"tailwind-merge": "^2.2.1",
 		"tailwind-variants": "^0.1.20"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       node-schedule:
         specifier: ^2.1.1
         version: 2.1.1
+      oslo:
+        specifier: ^1.2.1
+        version: 1.2.1
       svelte-sonner:
         specifier: ^0.3.11
         version: 0.3.24(svelte@4.2.18)
@@ -128,6 +131,12 @@ packages:
   '@babel/runtime@7.24.7':
     resolution: {integrity: sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==}
     engines: {node: '>=6.9.0'}
+
+  '@emnapi/core@0.45.0':
+    resolution: {integrity: sha512-DPWjcUDQkCeEM4VnljEOEcXdAD7pp8zSZsgOujk/LGIwCXWbXJngin+MO4zbH429lzeC3WbYLGjE2MaUOwzpyw==}
+
+  '@emnapi/runtime@0.45.0':
+    resolution: {integrity: sha512-Txumi3td7J4A/xTTwlssKieHKTGl3j4A1tglBx72auZ49YK7ePY6XZricgIg9mnZT4xPfA+UPCUdnhRuEFDL+w==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -315,6 +324,180 @@ packages:
     peerDependencies:
       svelte: '>=3 <5'
 
+  '@node-rs/argon2-android-arm-eabi@1.7.0':
+    resolution: {integrity: sha512-udDqkr5P9E+wYX1SZwAVPdyfYvaF4ry9Tm+R9LkfSHbzWH0uhU6zjIwNRp7m+n4gx691rk+lqqDAIP8RLKwbhg==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@node-rs/argon2-android-arm64@1.7.0':
+    resolution: {integrity: sha512-s9j/G30xKUx8WU50WIhF0fIl1EdhBGq0RQ06lEhZ0Gi0ap8lhqbE2Bn5h3/G2D1k0Dx+yjeVVNmt/xOQIRG38A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@node-rs/argon2-darwin-arm64@1.7.0':
+    resolution: {integrity: sha512-ZIz4L6HGOB9U1kW23g+m7anGNuTZ0RuTw0vNp3o+2DWpb8u8rODq6A8tH4JRL79S+Co/Nq608m9uackN2pe0Rw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@node-rs/argon2-darwin-x64@1.7.0':
+    resolution: {integrity: sha512-5oi/pxqVhODW/pj1+3zElMTn/YukQeywPHHYDbcAW3KsojFjKySfhcJMd1DjKTc+CHQI+4lOxZzSUzK7mI14Hw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@node-rs/argon2-freebsd-x64@1.7.0':
+    resolution: {integrity: sha512-Ify08683hA4QVXYoIm5SUWOY5DPIT/CMB0CQT+IdxQAg/F+qp342+lUkeAtD5bvStQuCx/dFO3bnnzoe2clMhA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@node-rs/argon2-linux-arm-gnueabihf@1.7.0':
+    resolution: {integrity: sha512-7DjDZ1h5AUHAtRNjD19RnQatbhL+uuxBASuuXIBu4/w6Dx8n7YPxwTP4MXfsvuRgKuMWiOb/Ub/HJ3kXVCXRkg==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@node-rs/argon2-linux-arm64-gnu@1.7.0':
+    resolution: {integrity: sha512-nJDoMP4Y3YcqGswE4DvP080w6O24RmnFEDnL0emdI8Nou17kNYBzP2546Nasx9GCyLzRcYQwZOUjrtUuQ+od2g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@node-rs/argon2-linux-arm64-musl@1.7.0':
+    resolution: {integrity: sha512-BKWS8iVconhE3jrb9mj6t1J9vwUqQPpzCbUKxfTGJfc+kNL58F1SXHBoe2cDYGnHrFEHTY0YochzXoAfm4Dm/A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@node-rs/argon2-linux-x64-gnu@1.7.0':
+    resolution: {integrity: sha512-EmgqZOlf4Jurk/szW1iTsVISx25bKksVC5uttJDUloTgsAgIGReCpUUO1R24pBhu9ESJa47iv8NSf3yAfGv6jQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@node-rs/argon2-linux-x64-musl@1.7.0':
+    resolution: {integrity: sha512-/o1efYCYIxjfuoRYyBTi2Iy+1iFfhqHCvvVsnjNSgO1xWiWrX0Rrt/xXW5Zsl7vS2Y+yu8PL8KFWRzZhaVxfKA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@node-rs/argon2-wasm32-wasi@1.7.0':
+    resolution: {integrity: sha512-Evmk9VcxqnuwQftfAfYEr6YZYSPLzmKUsbFIMep5nTt9PT4XYRFAERj7wNYp+rOcBenF3X4xoB+LhwcOMTNE5w==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@node-rs/argon2-win32-arm64-msvc@1.7.0':
+    resolution: {integrity: sha512-qgsU7T004COWWpSA0tppDqDxbPLgg8FaU09krIJ7FBl71Sz8SFO40h7fDIjfbTT5w7u6mcaINMQ5bSHu75PCaA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@node-rs/argon2-win32-ia32-msvc@1.7.0':
+    resolution: {integrity: sha512-JGafwWYQ/HpZ3XSwP4adQ6W41pRvhcdXvpzIWtKvX+17+xEXAe2nmGWM6s27pVkg1iV2ZtoYLRDkOUoGqZkCcg==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@node-rs/argon2-win32-x64-msvc@1.7.0':
+    resolution: {integrity: sha512-9oq4ShyFakw8AG3mRls0AoCpxBFcimYx7+jvXeAf2OqKNO+mSA6eZ9z7KQeVCi0+SOEUYxMGf5UiGiDb9R6+9Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@node-rs/argon2@1.7.0':
+    resolution: {integrity: sha512-zfULc+/tmcWcxn+nHkbyY8vP3+MpEqKORbszt4UkpqZgBgDAAIYvuDN/zukfTgdmo6tmJKKVfzigZOPk4LlIog==}
+    engines: {node: '>= 10'}
+
+  '@node-rs/bcrypt-android-arm-eabi@1.9.0':
+    resolution: {integrity: sha512-nOCFISGtnodGHNiLrG0WYLWr81qQzZKYfmwHc7muUeq+KY0sQXyHOwZk9OuNQAWv/lnntmtbwkwT0QNEmOyLvA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@node-rs/bcrypt-android-arm64@1.9.0':
+    resolution: {integrity: sha512-+ZrIAtigVmjYkqZQTThHVlz0+TG6D+GDHWhVKvR2DifjtqJ0i+mb9gjo++hN+fWEQdWNGxKCiBBjwgT4EcXd6A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@node-rs/bcrypt-darwin-arm64@1.9.0':
+    resolution: {integrity: sha512-CQiS+F9Pa0XozvkXR1g7uXE9QvBOPOplDg0iCCPRYTN9PqA5qYxhwe48G3o+v2UeQceNRrbnEtWuANm7JRqIhw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@node-rs/bcrypt-darwin-x64@1.9.0':
+    resolution: {integrity: sha512-4pTKGawYd7sNEjdJ7R/R67uwQH1VvwPZ0SSUMmeNHbxD5QlwAPXdDH11q22uzVXsvNFZ6nGQBg8No5OUGpx6Ug==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@node-rs/bcrypt-freebsd-x64@1.9.0':
+    resolution: {integrity: sha512-UmWzySX4BJhT/B8xmTru6iFif3h0Rpx3TqxRLCcbgmH43r7k5/9QuhpiyzpvKGpKHJCFNm4F3rC2wghvw5FCIg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@node-rs/bcrypt-linux-arm-gnueabihf@1.9.0':
+    resolution: {integrity: sha512-8qoX4PgBND2cVwsbajoAWo3NwdfJPEXgpCsZQZURz42oMjbGyhhSYbovBCskGU3EBLoC8RA2B1jFWooeYVn5BA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@node-rs/bcrypt-linux-arm64-gnu@1.9.0':
+    resolution: {integrity: sha512-TuAC6kx0SbcIA4mSEWPi+OCcDjTQUMl213v5gMNlttF+D4ieIZx6pPDGTaMO6M2PDHTeCG0CBzZl0Lu+9b0c7Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@node-rs/bcrypt-linux-arm64-musl@1.9.0':
+    resolution: {integrity: sha512-/sIvKDABOI8QOEnLD7hIj02BVaNOuCIWBKvxcJOt8+TuwJ6zmY1UI5kSv9d99WbiHjTp97wtAUbZQwauU4b9ew==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@node-rs/bcrypt-linux-x64-gnu@1.9.0':
+    resolution: {integrity: sha512-DyyhDHDsLBsCKz1tZ1hLvUZSc1DK0FU0v52jK6IBQxrj24WscSU9zZe7ie/V9kdmA4Ep57BfpWX8Dsa2JxGdgQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@node-rs/bcrypt-linux-x64-musl@1.9.0':
+    resolution: {integrity: sha512-duIiuqQ+Lew8ASSAYm6ZRqcmfBGWwsi81XLUwz86a2HR7Qv6V4yc3ZAUQovAikhjCsIqe8C11JlAZSK6+PlXYg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@node-rs/bcrypt-wasm32-wasi@1.9.0':
+    resolution: {integrity: sha512-ylaGmn9Wjwv/D5lxtawttx3H6Uu2WTTR7lWlRHGT6Ga/MB1Vj4OjSGUW8G8zIVnKuXpGbZ92pgHlt4HUpSLctw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@node-rs/bcrypt-win32-arm64-msvc@1.9.0':
+    resolution: {integrity: sha512-2h86gF7QFyEzODuDFml/Dp1MSJoZjxJ4yyT2Erf4NkwsiA5MqowUhUsorRwZhX6+2CtlGa7orbwi13AKMsYndw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@node-rs/bcrypt-win32-ia32-msvc@1.9.0':
+    resolution: {integrity: sha512-kqxalCvhs4FkN0+gWWfa4Bdy2NQAkfiqq/CEf6mNXC13RSV673Ev9V8sRlQyNpCHCNkeXfOT9pgoBdJmMs9muA==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@node-rs/bcrypt-win32-x64-msvc@1.9.0':
+    resolution: {integrity: sha512-2y0Tuo6ZAT2Cz8V7DHulSlv1Bip3zbzeXyeur+uR25IRNYXKvI/P99Zl85Fbuu/zzYAZRLLlGTRe6/9IHofe/w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@node-rs/bcrypt@1.9.0':
+    resolution: {integrity: sha512-u2OlIxW264bFUfvbFqDz9HZKFjwe8FHFtn7T/U8mYjPZ7DWYpbUB+/dkW/QgYfMSfR0ejkyuWaBBe0coW7/7ig==}
+    engines: {node: '>= 10'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -487,6 +670,9 @@ packages:
     engines: {node: '>= 10'}
     peerDependencies:
       svelte: ^3 || ^4 || ^5
+
+  '@tybys/wasm-util@0.8.3':
+    resolution: {integrity: sha512-Z96T/L6dUFFxgFJ+pQtkPpne9q7i6kIPYCFnQBHSgSPV9idTsKfIhCss0h5iM9irweZCatkrdeP8yi5uM1eX6Q==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -895,6 +1081,9 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
+  fs-monkey@1.0.6:
+    resolution: {integrity: sha512-b1FMfwetIKymC0eioW7mTywihSQE4oLzQn1dB6rZB5fx/3NpNEdAWeCSMB+60/AeT0TCXsxzAlcYVEFCTAksWg==}
+
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -1194,6 +1383,13 @@ packages:
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
 
+  memfs-browser@3.5.10302:
+    resolution: {integrity: sha512-JJTc/nh3ig05O0gBBGZjTCPOyydaTxNF0uHYBrcc1gHNnO+KIHIvo0Y1FKCJsaei6FCl8C6xfQomXqu+cuzkIw==}
+
+  memfs@3.5.3:
+    resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
+    engines: {node: '>= 4.0.0'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -1327,6 +1523,9 @@ packages:
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
+
+  oslo@1.2.1:
+    resolution: {integrity: sha512-HfIhB5ruTdQv0XX2XlncWQiJ5SIHZ7NHZhVyHth0CSZ/xzge00etRyYy/3wp/Dsu+PkxMC+6+B2lS/GcKoewkA==}
 
   p-limit@5.0.0:
     resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
@@ -1975,6 +2174,16 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.1
 
+  '@emnapi/core@0.45.0':
+    dependencies:
+      tslib: 2.6.3
+    optional: true
+
+  '@emnapi/runtime@0.45.0':
+    dependencies:
+      tslib: 2.6.3
+    optional: true
+
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
@@ -2108,6 +2317,134 @@ snapshots:
       focus-trap: 7.5.4
       nanoid: 5.0.7
       svelte: 4.2.18
+
+  '@node-rs/argon2-android-arm-eabi@1.7.0':
+    optional: true
+
+  '@node-rs/argon2-android-arm64@1.7.0':
+    optional: true
+
+  '@node-rs/argon2-darwin-arm64@1.7.0':
+    optional: true
+
+  '@node-rs/argon2-darwin-x64@1.7.0':
+    optional: true
+
+  '@node-rs/argon2-freebsd-x64@1.7.0':
+    optional: true
+
+  '@node-rs/argon2-linux-arm-gnueabihf@1.7.0':
+    optional: true
+
+  '@node-rs/argon2-linux-arm64-gnu@1.7.0':
+    optional: true
+
+  '@node-rs/argon2-linux-arm64-musl@1.7.0':
+    optional: true
+
+  '@node-rs/argon2-linux-x64-gnu@1.7.0':
+    optional: true
+
+  '@node-rs/argon2-linux-x64-musl@1.7.0':
+    optional: true
+
+  '@node-rs/argon2-wasm32-wasi@1.7.0':
+    dependencies:
+      '@emnapi/core': 0.45.0
+      '@emnapi/runtime': 0.45.0
+      '@tybys/wasm-util': 0.8.3
+      memfs-browser: 3.5.10302
+    optional: true
+
+  '@node-rs/argon2-win32-arm64-msvc@1.7.0':
+    optional: true
+
+  '@node-rs/argon2-win32-ia32-msvc@1.7.0':
+    optional: true
+
+  '@node-rs/argon2-win32-x64-msvc@1.7.0':
+    optional: true
+
+  '@node-rs/argon2@1.7.0':
+    optionalDependencies:
+      '@node-rs/argon2-android-arm-eabi': 1.7.0
+      '@node-rs/argon2-android-arm64': 1.7.0
+      '@node-rs/argon2-darwin-arm64': 1.7.0
+      '@node-rs/argon2-darwin-x64': 1.7.0
+      '@node-rs/argon2-freebsd-x64': 1.7.0
+      '@node-rs/argon2-linux-arm-gnueabihf': 1.7.0
+      '@node-rs/argon2-linux-arm64-gnu': 1.7.0
+      '@node-rs/argon2-linux-arm64-musl': 1.7.0
+      '@node-rs/argon2-linux-x64-gnu': 1.7.0
+      '@node-rs/argon2-linux-x64-musl': 1.7.0
+      '@node-rs/argon2-wasm32-wasi': 1.7.0
+      '@node-rs/argon2-win32-arm64-msvc': 1.7.0
+      '@node-rs/argon2-win32-ia32-msvc': 1.7.0
+      '@node-rs/argon2-win32-x64-msvc': 1.7.0
+
+  '@node-rs/bcrypt-android-arm-eabi@1.9.0':
+    optional: true
+
+  '@node-rs/bcrypt-android-arm64@1.9.0':
+    optional: true
+
+  '@node-rs/bcrypt-darwin-arm64@1.9.0':
+    optional: true
+
+  '@node-rs/bcrypt-darwin-x64@1.9.0':
+    optional: true
+
+  '@node-rs/bcrypt-freebsd-x64@1.9.0':
+    optional: true
+
+  '@node-rs/bcrypt-linux-arm-gnueabihf@1.9.0':
+    optional: true
+
+  '@node-rs/bcrypt-linux-arm64-gnu@1.9.0':
+    optional: true
+
+  '@node-rs/bcrypt-linux-arm64-musl@1.9.0':
+    optional: true
+
+  '@node-rs/bcrypt-linux-x64-gnu@1.9.0':
+    optional: true
+
+  '@node-rs/bcrypt-linux-x64-musl@1.9.0':
+    optional: true
+
+  '@node-rs/bcrypt-wasm32-wasi@1.9.0':
+    dependencies:
+      '@emnapi/core': 0.45.0
+      '@emnapi/runtime': 0.45.0
+      '@tybys/wasm-util': 0.8.3
+      memfs-browser: 3.5.10302
+    optional: true
+
+  '@node-rs/bcrypt-win32-arm64-msvc@1.9.0':
+    optional: true
+
+  '@node-rs/bcrypt-win32-ia32-msvc@1.9.0':
+    optional: true
+
+  '@node-rs/bcrypt-win32-x64-msvc@1.9.0':
+    optional: true
+
+  '@node-rs/bcrypt@1.9.0':
+    optionalDependencies:
+      '@node-rs/bcrypt-android-arm-eabi': 1.9.0
+      '@node-rs/bcrypt-android-arm64': 1.9.0
+      '@node-rs/bcrypt-darwin-arm64': 1.9.0
+      '@node-rs/bcrypt-darwin-x64': 1.9.0
+      '@node-rs/bcrypt-freebsd-x64': 1.9.0
+      '@node-rs/bcrypt-linux-arm-gnueabihf': 1.9.0
+      '@node-rs/bcrypt-linux-arm64-gnu': 1.9.0
+      '@node-rs/bcrypt-linux-arm64-musl': 1.9.0
+      '@node-rs/bcrypt-linux-x64-gnu': 1.9.0
+      '@node-rs/bcrypt-linux-x64-musl': 1.9.0
+      '@node-rs/bcrypt-wasm32-wasi': 1.9.0
+      '@node-rs/bcrypt-win32-arm64-msvc': 1.9.0
+      '@node-rs/bcrypt-win32-ia32-msvc': 1.9.0
+      '@node-rs/bcrypt-win32-x64-msvc': 1.9.0
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -2270,6 +2607,11 @@ snapshots:
     dependencies:
       '@testing-library/dom': 9.3.4
       svelte: 4.2.18
+
+  '@tybys/wasm-util@0.8.3':
+    dependencies:
+      tslib: 2.6.3
+    optional: true
 
   '@types/aria-query@5.0.4': {}
 
@@ -2728,6 +3070,9 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
+  fs-monkey@1.0.6:
+    optional: true
+
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.2:
@@ -3017,6 +3362,16 @@ snapshots:
 
   mdn-data@2.0.30: {}
 
+  memfs-browser@3.5.10302:
+    dependencies:
+      memfs: 3.5.3
+    optional: true
+
+  memfs@3.5.3:
+    dependencies:
+      fs-monkey: 1.0.6
+    optional: true
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -3126,6 +3481,11 @@ snapshots:
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
+
+  oslo@1.2.1:
+    dependencies:
+      '@node-rs/argon2': 1.7.0
+      '@node-rs/bcrypt': 1.9.0
 
   p-limit@5.0.0:
     dependencies:

--- a/scripts/weapons.py
+++ b/scripts/weapons.py
@@ -72,9 +72,12 @@ enable_img_download = '--enable-img-download' in sys.argv
 test_run = '--test-run' in sys.argv
 
 if enable_img_download:
-  print("Image download enabled")
+  print("INFO: Image download enabled")
 else:
-  print("Image download disabled")
+  print("INFO: Image download disabled")
+
+if test_run:
+  print("INFO: Test run enabled - Only scraping the first 5 weapons")
 
 # Go to the wiki page
 BASE_URL = "https://wiki.teamfortress.com"
@@ -131,7 +134,7 @@ for weapon in weapons.values():
   # Prevent getting blocked by the server
   time.sleep(2)
 
-  print(f"#### Scraping {weapon.name} #### {index}/{len(weapons)}")
+  print(f"RUNNING: Scraping {weapon.name} ({index}/{len(weapons)})")
   index += 1
 
   # Load weapon page
@@ -191,7 +194,10 @@ for weapon in weapons.values():
 
   # Find attributes
   attribute_container = weapon_soup.find("td", class_="loadout-tooltip-container")
-  attributes = attribute_container.find_all("span", class_=lambda x: x and x.startswith("att_"))
+  if attribute_container:
+    attributes = attribute_container.find_all("span", class_=lambda x: x and x.startswith("att_"))
+  else:
+    attributes = []
   
   for attribute in attributes:
     attribute_class = attribute.get("class")[0]
@@ -202,7 +208,6 @@ for weapon in weapons.values():
     attribute_text = attribute.text
 
     # Replace weapon name with ___ to not give it away
-    # TODO: Test if this works
     attribute_text = attribute_text.replace(weapon.name, "___")
 
     if attribute_class in attribute_class_map.keys():

--- a/scripts/weapons.py
+++ b/scripts/weapons.py
@@ -201,6 +201,10 @@ for weapon in weapons.values():
 
     attribute_text = attribute.text
 
+    # Replace weapon name with ___ to not give it away
+    # TODO: Test if this works
+    attribute_text = attribute_text.replace(weapon.name, "___")
+
     if attribute_class in attribute_class_map.keys():
       weapon.add_attribute(Attribute(attribute_text, attribute_class_map[attribute_class]))
 

--- a/src/lib/components/layouts/Header.svelte
+++ b/src/lib/components/layouts/Header.svelte
@@ -7,8 +7,6 @@
 	const lastPatchNote = patchNotes[0];
 
 	$: hasViewedPatchNotes = $lastViewedPatchNote === lastPatchNote.version;
-
-	$: console.log($lastViewedPatchNote);
 </script>
 
 <header class="flex items-center justify-center">

--- a/src/lib/patchNotes/index.ts
+++ b/src/lib/patchNotes/index.ts
@@ -13,6 +13,7 @@ import patch_1_6_1 from './patch_1_6_1';
 import patch_1_7_0 from './patch_1_7_0';
 import patch_1_7_1 from './patch_1_7_1';
 import patch_1_7_2 from './patch_1_7_2';
+import type { PatchNote } from './types';
 
 const patchNotes = [
 	patch_1_7_2,
@@ -29,7 +30,7 @@ const patchNotes = [
 	patch_1_0_0,
 	patch_0_2_0,
 	patch_0_1_0
-];
+] as PatchNote[];
 
 export default patchNotes;
 

--- a/src/lib/patchNotes/index.ts
+++ b/src/lib/patchNotes/index.ts
@@ -12,8 +12,10 @@ import patch_1_6_0 from './patch_1_6_0';
 import patch_1_6_1 from './patch_1_6_1';
 import patch_1_7_0 from './patch_1_7_0';
 import patch_1_7_1 from './patch_1_7_1';
+import patch_1_7_2 from './patch_1_7_2';
 
 const patchNotes = [
+	patch_1_7_2,
 	patch_1_7_1,
 	patch_1_7_0,
 	patch_1_6_1,

--- a/src/lib/patchNotes/patch_0_1_0.ts
+++ b/src/lib/patchNotes/patch_0_1_0.ts
@@ -7,12 +7,12 @@ export default {
 		{
 			title: 'Patch notes',
 			description: 'Added this page for patch notes.',
-			gameMode: 'all'
+			gameMode: 'All Game Modes'
 		},
 		{
 			title: 'Jungle Inferno Weapons',
 			description: 'Added Jungle Inferno weapons to the weapon game mode.',
-			gameMode: 'weapon'
+			gameMode: 'Weapon'
 		}
 	],
 	improvements: [
@@ -20,17 +20,17 @@ export default {
 			title: 'Fixed search filtering algorithm',
 			description:
 				'Previously, it search only for words starting with the search query. Now it searches for words containing the search query making it easier to find what you are looking for.',
-			gameMode: 'all'
+			gameMode: 'All Game Modes'
 		},
 		{
 			title: 'Consistent feedback messages',
 			description: 'The feedback messegaes are now consistent throughout the different gamemodes.',
-			gameMode: 'all'
+			gameMode: 'All Game Modes'
 		},
 		{
 			title: 'Made map gamemode easier',
 			description: 'Picture of the map starts less zoomed in making it easier to guess the map.',
-			gameMode: 'map',
+			gameMode: 'Map',
 			tag: 'improvment'
 		}
 	],
@@ -38,7 +38,7 @@ export default {
 		{
 			title: 'Fixed game reset bug',
 			description: 'A bug where the games would reset multiple times a day is now fixed.',
-			gameMode: 'all'
+			gameMode: 'All Game Modes'
 		}
 	]
 } as PatchNote;

--- a/src/lib/patchNotes/patch_0_2_0.ts
+++ b/src/lib/patchNotes/patch_0_2_0.ts
@@ -7,7 +7,7 @@ export default {
 			title: 'Clear map hints',
 			description:
 				'As maps only have two hints (game mode and release year) some maps have the same hints, meaning the UI would tell you that you had everything correct when in fact it was the wrong map. Now, the image also has a colored border to indicate whether you have the correct map or not.',
-			gameMode: 'map'
+			gameMode: 'Map'
 		}
 	],
 	bugFixes: [
@@ -15,24 +15,24 @@ export default {
 			title: 'Fix map cheat',
 			description:
 				'You can no longer drag the map image to see the full image when it is zoomed in.',
-			gameMode: 'map'
+			gameMode: 'Map'
 		},
 		{
 			title: 'Typos in table headers',
 			description: 'Fixed typos in table headers.',
-			gameMode: 'weapon'
+			gameMode: 'Weapon'
 		},
 		{
 			title: 'Timer not resetting at midnight',
 			description:
 				'Timer would continue to count down after midnight with negative values. Should now reset as expected.',
-			gameMode: 'all'
+			gameMode: 'All Game Modes'
 		},
 		{
 			title: 'Challenge completion bug',
 			description:
 				"Previously, when first loading the page it would sometimes tell you that you had completed the challenge when you hand't. This should now be fixed.",
-			gameMode: 'all'
+			gameMode: 'All Game Modes'
 		}
 	]
 };

--- a/src/lib/patchNotes/patch_1_0_0.ts
+++ b/src/lib/patchNotes/patch_1_0_0.ts
@@ -5,19 +5,19 @@ export default {
 		{
 			title: 'Version 1',
 			description: 'The game is now out of beta and is now version 1.0.0',
-			gameMode: 'all'
+			gameMode: 'All Game Modes'
 		},
 		{
 			title: 'New game mode: Cosmetics',
 			description: 'Added a new game mode where you have to guess the correct cosmetic.',
-			gameMode: 'cosmetic'
+			gameMode: 'Cosmetic'
 		}
 	],
 	improvements: [
 		{
 			title: 'Mobile support',
 			description: 'The weapon game mode is now better supported on mobile devices.',
-			gameMode: 'weapon'
+			gameMode: 'Weapon'
 		}
 	],
 	bugFixes: []

--- a/src/lib/patchNotes/patch_1_1_0.ts
+++ b/src/lib/patchNotes/patch_1_1_0.ts
@@ -5,20 +5,20 @@ export default {
 		{
 			title: 'Next game mode navigation',
 			description: 'Can now navigate to the next game mode from the victory dialog.',
-			gameMode: 'all'
+			gameMode: 'All Game Modes'
 		}
 	],
 	improvements: [
 		{
 			title: 'Re-orderd weapon hints',
 			description: 'Weapon hints are now ordered in a more logical way.',
-			gameMode: 'weapon'
+			gameMode: 'Weapon'
 		},
 		{
 			title: 'Made cosmetic easier',
 			description:
 				'The hints for the cosmetics are now given at 3, 6, and 9 tries instead of 5, 10, and 15.',
-			gameMode: 'cosmetic'
+			gameMode: 'Cosmetic'
 		}
 	],
 	bugFixes: [
@@ -26,12 +26,12 @@ export default {
 			title: 'Fix grayfilter on mobile',
 			description:
 				'Grayfilter was not applied to cosmeitc on mobile devices. This should now be fixed.',
-			gameMode: 'cosmetic'
+			gameMode: 'Cosmetic'
 		},
 		{
 			title: 'Fix streak reset',
 			description: "Streak will now proparly reset if you don't guess correct within two days",
-			gameMode: ['weapon', 'cosmetic']
+			gameMode: ['Weapon', 'Cosmetic']
 		}
 	]
 };

--- a/src/lib/patchNotes/patch_1_2_0.ts
+++ b/src/lib/patchNotes/patch_1_2_0.ts
@@ -6,7 +6,7 @@ export default {
 			title: 'Color blind mode',
 			description:
 				'Color blind mode can be activated in the settings. Click on the gear icon to the left of the logo and toggle the color blind mode option. Additionally, colors displaying correct/incorrect/partial is now displayed as background color and not borders make it easier to distinguish.',
-			gameMode: 'all'
+			gameMode: 'All Game Modes'
 		}
 	],
 	improvements: [],
@@ -15,7 +15,7 @@ export default {
 			title: 'Use correct url when sharing to twitter',
 			description:
 				'Tweet template used the old url, this should now be update to the new url (tf2dle.com).',
-			gameMode: 'all'
+			gameMode: 'All Game Modes'
 		}
 	]
 };

--- a/src/lib/patchNotes/patch_1_3_0.ts
+++ b/src/lib/patchNotes/patch_1_3_0.ts
@@ -8,13 +8,13 @@ export default {
 			title: 'Timing bug',
 			description:
 				'If you guessed correct some seconds before midnight, the server would validate it to correct, and if by the time it reached the client, a new day had started, it would be marked as if you had guessed the new days puzzle. This has been fixed and should no longer be an issue',
-			gameMode: 'all'
+			gameMode: 'All Game Modes'
 		},
 		{
 			title: 'Cosmetic color show when correct',
 			description:
 				"Previously, the gray filter of the cosmetic would still be applied when you guessed correct cosmetic prior to the color hint. This has been fixed and the gray filter will now be removed whenever you guess the correct cosmetic, regardless if it's prior to the color hint or not.",
-			gameMode: 'cosmetics'
+			gameMode: 'Cosmetics'
 		}
 	]
 };

--- a/src/lib/patchNotes/patch_1_4_0.ts
+++ b/src/lib/patchNotes/patch_1_4_0.ts
@@ -6,7 +6,7 @@ export default {
 			title: 'Stats',
 			description:
 				'Stats have been added! Everytime you complete a daily challenge, the attempt is recorded and you can view a graph of your stats. The stats are only stored locally in your browser and you can clear your stats at any time in the settings dialog!',
-			gameMode: 'All'
+			gameMode: 'All Game Modes'
 		}
 	],
 	improvements: [],

--- a/src/lib/patchNotes/patch_1_5_0.ts
+++ b/src/lib/patchNotes/patch_1_5_0.ts
@@ -6,7 +6,7 @@ export default {
 			title: 'Quick commands',
 			description:
 				'Added a quick command components that allows you to more easily perform actions on the application with keyboard shortcuts. Quick commands can be access either by pressing the button in the top left corner or CTRL/CMD + K on your keyboard!',
-			gameMode: 'All'
+			gameMode: 'All Game Modes'
 		}
 	],
 	improvements: [],

--- a/src/lib/patchNotes/patch_1_6_1.ts
+++ b/src/lib/patchNotes/patch_1_6_1.ts
@@ -7,8 +7,15 @@ export default {
 		{
 			title: 'Add color hint behind item icon',
 			description:
-				'As some items have the same hints, it could sometimes be confusing to know if you have completed the daily challenge. A background color has been added to indicate wether the guess was correct or not. Thanks to <a href="https://www.reddit.com/user/_Klush_/" target="_blank" class="patch-link">Klush</a> for bringing this to my attention!',
-			gameMode: 'Weapons'
+				'As some items have the same hints, it could sometimes be confusing to know if you have completed the daily challenge. A background color has been added to indicate wether the guess was correct or not.',
+			gameMode: 'Weapons',
+			reportedBy: {
+				user: {
+					name: 'Klush',
+					link: 'https://www.reddit.com/user/_Klush_/"'
+				},
+				note: 'Thanks for bringing this to my attention!'
+			}
 		}
 	]
 };

--- a/src/lib/patchNotes/patch_1_7_0.ts
+++ b/src/lib/patchNotes/patch_1_7_0.ts
@@ -5,8 +5,15 @@ export default {
 		{
 			title: 'New game mode: Weapon 2!',
 			description:
-				'The new <a href="/game-modes/weapon-2" class="patch-link">weapon game mode</a> is now available! Guess daily weapons based on its attributes show in-game. Big thanks to <a href="https://www.reddit.com/user/becausewhybnot/" target="_blank" class="patch-link">becausewhybnot</a> for recommending the game mode!',
-			gameMode: 'Weapon 2'
+				'The new <a href="/game-modes/weapon-2" class="patch-link">weapon game mode</a> is now available! Guess daily weapons based on its attributes show in-game.',
+			gameMode: 'Weapon 2',
+			reportedBy: {
+				user: {
+					name: 'becausewhybnot',
+					link: 'https://www.reddit.com/user/becausewhybnot/'
+				},
+				note: 'Big thanks for the suggestion!'
+			}
 		}
 	],
 	improvements: [],

--- a/src/lib/patchNotes/patch_1_7_2.ts
+++ b/src/lib/patchNotes/patch_1_7_2.ts
@@ -1,0 +1,14 @@
+export default {
+	version: '1.7.2',
+	date: '18.10.2024',
+	newFeatures: [],
+	improvements: [
+		{
+			title: 'Updated randomizer',
+			description:
+				'Noticed that the same items were being selected too frequently. The randomizer has been updated, hoping to fix this issue.',
+			gameMode: 'All'
+		}
+	],
+	bugFixes: []
+};

--- a/src/lib/patchNotes/patch_1_7_2.ts
+++ b/src/lib/patchNotes/patch_1_7_2.ts
@@ -7,8 +7,22 @@ export default {
 			title: 'Updated randomizer',
 			description:
 				'Noticed that the same items were being selected too frequently. The randomizer has been updated, hoping to fix this issue.',
-			gameMode: 'All'
+			gameMode: 'All Game Modes'
 		}
 	],
-	bugFixes: []
+	bugFixes: [
+		{
+			title: 'Hide item names from hints',
+			description:
+				'Replaces item names in hints with a placeholder. Hopyfully, all Game Modes item names are now hidden, but exceptions may still exist.',
+			gameMode: 'Weapon 2',
+			reportedBy: {
+				user: {
+					name: 'VaniRabbit',
+					link: 'https://www.reddit.com/user/VaniRabbit/'
+				},
+				note: 'Thanks for reporting this issue!'
+			}
+		}
+	]
 };

--- a/src/lib/patchNotes/patch_1_7_2.ts
+++ b/src/lib/patchNotes/patch_1_7_2.ts
@@ -14,7 +14,7 @@ export default {
 		{
 			title: 'Hide item names from hints',
 			description:
-				'Replaces item names in hints with a placeholder. Hopyfully, all Game Modes item names are now hidden, but exceptions may still exist.',
+				'Replaces item names in hints with a placeholder. Hopyfully, all item names are now hidden, but exceptions may still exist.',
 			gameMode: 'Weapon 2',
 			reportedBy: {
 				user: {

--- a/src/lib/patchNotes/types.ts
+++ b/src/lib/patchNotes/types.ts
@@ -10,4 +10,11 @@ export type Change = {
 	title: string;
 	description: string;
 	gameMode: string | string[];
+	reportedBy?: {
+		user: {
+			name: string;
+			link: string;
+		};
+		note: string;
+	};
 };

--- a/src/lib/server/data/weapons.json
+++ b/src/lib/server/data/weapons.json
@@ -1,6177 +1,6177 @@
 [
-  {
-    "name": "Scattergun",
-    "link": "/wiki/Scattergun",
-    "image": "/w/images/thumb/1/1b/Item_icon_Scattergun.png/100px-Item_icon_Scattergun.png",
-    "killIcon": "/w/images/3/34/Killicon_scattergun.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Scout"],
-    "slot": ["Primary"],
-    "ammoLoaded": "6",
-    "ammoCarried": "32",
-    "reloadType": "Single\n  ",
-    "qualities": ["Normal", "Unique", "Strange", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 Scattergun",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Force-A-Nature",
-    "link": "/wiki/Force-A-Nature",
-    "image": "/w/images/thumb/e/ed/Item_icon_Force-A-Nature.png/100px-Item_icon_Force-A-Nature.png",
-    "killIcon": "/w/images/5/51/Killicon_force-a-nature.png",
-    "releaseDate": "February 24, 2009 Patch(Scout Update)",
-    "usedBy": ["Scout"],
-    "slot": ["Primary"],
-    "ammoLoaded": "2",
-    "ammoCarried": "32",
-    "reloadType": "Clip\n  ",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Scattergun",
-        "variant": "level"
-      },
-      {
-        "text": "+50% faster firing speed",
-        "variant": "positive"
-      },
-      {
-        "text": "Knockback on the target and shooter",
-        "variant": "positive"
-      },
-      {
-        "text": "+20% bullets per shot",
-        "variant": "positive"
-      },
-      {
-        "text": "-10% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "-66% clip size",
-        "variant": "negative"
-      },
-      {
-        "text": "This weapon reloads its entire clip at once",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Shortstop",
-    "link": "/wiki/Shortstop",
-    "image": "/w/images/thumb/8/84/Item_icon_Shortstop.png/100px-Item_icon_Shortstop.png",
-    "killIcon": "/w/images/2/2b/Killicon_shortstop.png",
-    "releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
-    "usedBy": ["Scout"],
-    "slot": ["Primary"],
-    "ammoLoaded": "4",
-    "ammoCarried": "32",
-    "reloadType": "Clip\n  ",
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 Peppergun",
-        "variant": "level"
-      },
-      {
-        "text": " When weapon is active: ",
-        "variant": "neutral"
-      },
-      {
-        "text": "Increase in push force taken from damage and airblast",
-        "variant": "negative"
-      },
-      {
-        "text": "Holds a 4-shot clip and reloads its entire clip at once.\nAlt-Fire to reach and shove someone!\n\nMann Co.'s latest in high attitude\nbreak-action personal defense.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Soda Popper",
-    "link": "/wiki/Soda_Popper",
-    "image": "/w/images/thumb/f/f1/Item_icon_Soda_Popper.png/100px-Item_icon_Soda_Popper.png",
-    "killIcon": "/w/images/3/34/Killicon_soda_popper.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Scout"],
-    "slot": ["Primary"],
-    "ammoLoaded": "2",
-    "ammoCarried": "32",
-    "reloadType": "Clip\n  ",
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 10 Scattergun",
-        "variant": "level"
-      },
-      {
-        "text": "+50% faster firing speed",
-        "variant": "positive"
-      },
-      {
-        "text": "25% faster reload time",
-        "variant": "positive"
-      },
-      {
-        "text": "On Hit: Builds Hype",
-        "variant": "positive"
-      },
-      {
-        "text": "-66% clip size",
-        "variant": "negative"
-      },
-      {
-        "text": "When Hype is full, Alt-Fire to activate Hype mode for multiple air jumps.\nThis weapon reloads its entire clip at once.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Baby Face's Blaster",
-    "link": "/wiki/Baby_Face%27s_Blaster",
-    "image": "/w/images/thumb/e/e6/Item_icon_Baby_Face%27s_Blaster.png/100px-Item_icon_Baby_Face%27s_Blaster.png",
-    "killIcon": "/w/images/5/56/Killicon_baby_face%27s_blaster.png",
-    "releaseDate": "June 27, 2012 Patch(Pyromania Update)",
-    "usedBy": ["Scout"],
-    "slot": ["Primary"],
-    "ammoLoaded": "4",
-    "ammoCarried": "32",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Scattergun",
-        "variant": "level"
-      },
-      {
-        "text": "On Hit: Builds Boost\nRun speed increased with Boost",
-        "variant": "positive"
-      },
-      {
-        "text": "-34% clip size",
-        "variant": "negative"
-      },
-      {
-        "text": "10% slower move speed on wearer",
-        "variant": "negative"
-      },
-      {
-        "text": "Boost reduced on air jumps",
-        "variant": "negative"
-      },
-      {
-        "text": "Boost reduced when hit",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Back Scatter",
-    "link": "/wiki/Back_Scatter",
-    "image": "/w/images/thumb/1/11/Item_icon_Back_Scatter.png/100px-Item_icon_Back_Scatter.png",
-    "killIcon": "/w/images/b/b9/Killicon_back_scatter.png",
-    "releaseDate": "June 18, 2014 Patch(Love & War Update)",
-    "usedBy": ["Scout"],
-    "slot": ["Primary"],
-    "ammoLoaded": "4",
-    "ammoCarried": "32",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Scattergun",
-        "variant": "level"
-      },
-      {
-        "text": "Mini-crits targets when fired at their back from close range",
-        "variant": "positive"
-      },
-      {
-        "text": "-34% clip size",
-        "variant": "negative"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "20% less accurate",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Pistol",
-    "link": "/wiki/Pistol",
-    "image": "/w/images/thumb/5/52/Item_icon_Pistol.png/100px-Item_icon_Pistol.png",
-    "killIcon": "/w/images/1/1a/Killicon_pistol.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Scout", "Engineer"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "12",
-    "ammoCarried": "36 (Scout)200 (Engineer)",
-    "reloadType": "Clip\n  ",
-    "qualities": ["Normal", "Unique", "Strange", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 Pistol",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Lugermorph",
-    "link": "/wiki/Lugermorph",
-    "image": "/w/images/thumb/8/86/Item_icon_Lugermorph.png/100px-Item_icon_Lugermorph.png",
-    "killIcon": "/w/images/e/e7/Killicon_lugermorph.png",
-    "releaseDate": "April 15, 2010 Patch",
-    "usedBy": ["Scout", "Engineer"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "12",
-    "ammoCarried": "36 (Scout)200 (Engineer)",
-    "reloadType": "Clip\n  ",
-    "qualities": ["Unique", "Vintage"],
-    "attributes": [
-      {
-        "text": "Level 5 Pistol",
-        "variant": "level"
-      },
-      {
-        "text": "The ultimate in semi-concealed weaponry. There's no question you need this gun, the only question is: where will you keep it?",
-        "variant": "neutral"
-      },
-      {
-        "text": "( Achievement Item: Not Tradable or Marketable )",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "C.A.P.P.E.R",
-    "link": "/wiki/C.A.P.P.E.R",
-    "image": "/w/images/thumb/a/a6/Item_icon_C.A.P.P.E.R.png/100px-Item_icon_C.A.P.P.E.R.png",
-    "killIcon": "/w/images/e/e0/Killicon_c.a.p.p.e.r.png",
-    "releaseDate": "October 6, 2015 Patch(Invasion Community Update)",
-    "usedBy": ["Scout", "Engineer"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "12",
-    "ammoCarried": "36 (Scout)200 (Engineer)",
-    "reloadType": "Clip\n  ",
-    "qualities": ["Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "\nPistol",
-        "variant": "level"
-      },
-      {
-        "text": "Turn your enemies in to ash!",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Winger",
-    "link": "/wiki/Winger",
-    "image": "/w/images/thumb/4/4e/Item_icon_Winger.png/100px-Item_icon_Winger.png",
-    "killIcon": "/w/images/3/35/Killicon_winger.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Scout"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "5",
-    "ammoCarried": "36",
-    "reloadType": "Clip\n  ",
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 15 Pistol",
-        "variant": "level"
-      },
-      {
-        "text": "+15% damage bonus",
-        "variant": "positive"
-      },
-      {
-        "text": "+25% greater jump height when active",
-        "variant": "positive"
-      },
-      {
-        "text": "-60% clip size",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Pretty Boy's Pocket Pistol",
-    "link": "/wiki/Pretty_Boy%27s_Pocket_Pistol",
-    "image": "/w/images/thumb/f/f6/Item_icon_Pretty_Boy%27s_Pocket_Pistol.png/100px-Item_icon_Pretty_Boy%27s_Pocket_Pistol.png",
-    "killIcon": "/w/images/b/b8/Killicon_pretty_boy%27s_pocket_pistol.png",
-    "releaseDate": "June 27, 2012 Patch(Pyromania Update)",
-    "usedBy": ["Scout"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "9",
-    "ammoCarried": "36",
-    "reloadType": "Clip\n  ",
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Pistol",
-        "variant": "level"
-      },
-      {
-        "text": " When weapon is active: ",
-        "variant": "neutral"
-      },
-      {
-        "text": "+15% faster firing speed",
-        "variant": "positive"
-      },
-      {
-        "text": "On Hit: Gain up to +3 health",
-        "variant": "positive"
-      },
-      {
-        "text": "-25% clip size",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Flying Guillotine",
-    "link": "/wiki/Flying_Guillotine",
-    "image": "/w/images/thumb/5/5a/Item_icon_Flying_Guillotine.png/100px-Item_icon_Flying_Guillotine.png",
-    "killIcon": "/w/images/f/ff/Killicon_flying_guillotine.png",
-    "releaseDate": "August 2, 2012 Patch(Triad Pack)",
-    "usedBy": ["Scout"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Genuine", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Cleaver",
-        "variant": "level"
-      },
-      {
-        "text": "Throw at your enemies to make them bleed!  Long distance hits reduce recharge time",
-        "variant": "positive"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Bonk! Atomic Punch",
-    "link": "/wiki/Bonk!_Atomic_Punch",
-    "image": "/w/images/thumb/8/8f/Item_icon_Bonk%21_Atomic_Punch.png/100px-Item_icon_Bonk%21_Atomic_Punch.png",
-    "killIcon": null,
-    "releaseDate": "February 24, 2009 Patch(Scout Update)",
-    "usedBy": ["Scout"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "Recharge (30 seconds)\n",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Lunch Box",
-        "variant": "level"
-      },
-      {
-        "text": "Drink to become invulnerable for 8 seconds.  Cannot attack during this time.\nDamage absorbed will slow you when the effect ends.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Crit-a-Cola",
-    "link": "/wiki/Crit-a-Cola",
-    "image": "/w/images/thumb/a/ae/Item_icon_Crit-a-Cola.png/100px-Item_icon_Crit-a-Cola.png",
-    "killIcon": null,
-    "releaseDate": "April 28, 2010 Patch",
-    "usedBy": ["Scout"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "Recharge (22 seconds)\n",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Lunch Box",
-        "variant": "level"
-      },
-      {
-        "text": "While effect is active: Each attack mini-crits and sets Marked-For-Death for 5 seconds.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Mad Milk",
-    "link": "/wiki/Mad_Milk",
-    "image": "/w/images/thumb/5/56/Item_icon_Mad_Milk.png/100px-Item_icon_Mad_Milk.png",
-    "killIcon": null,
-    "releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
-    "usedBy": ["Scout"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "Recharge (20 seconds)\n",
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Non-Milk Substance",
-        "variant": "level"
-      },
-      {
-        "text": "Extinguishing teammates reduces cooldown by -20%",
-        "variant": "positive"
-      },
-      {
-        "text": "Players heal 60% of the damage done\nto an enemy covered with milk.\nCan be used to extinguish fires.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Mutated Milk",
-    "link": "/wiki/Mutated_Milk",
-    "image": "/w/images/thumb/b/bd/Item_icon_Mutated_Milk.png/100px-Item_icon_Mutated_Milk.png",
-    "killIcon": null,
-    "releaseDate": "June 18, 2014 Patch(Love & War Update)",
-    "usedBy": ["Scout"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "Recharge (20 seconds)\n",
-    "qualities": ["Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "Extinguishing teammates reduces cooldown by -20%",
-        "variant": "positive"
-      },
-      {
-        "text": "Players heal 60% of the damage done to an enemy covered with milk.\n\nInspired by the TF2 Movie 'Expiration Date'",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Bat",
-    "link": "/wiki/Bat",
-    "image": "/w/images/thumb/b/b5/Item_icon_Bat.png/100px-Item_icon_Bat.png",
-    "killIcon": "/w/images/d/de/Killicon_bat.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Scout"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Normal", "Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "Level 1 Bat",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Holy Mackerel",
-    "link": "/wiki/Holy_Mackerel",
-    "image": "/w/images/thumb/8/86/Item_icon_Holy_Mackerel.png/100px-Item_icon_Holy_Mackerel.png",
-    "killIcon": "/w/images/e/e7/Killicon_holy_mackerel.png",
-    "releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
-    "usedBy": ["Scout"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 42 Fish",
-        "variant": "level"
-      },
-      {
-        "text": "Getting hit by a fish has got to be humiliating.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Unarmed Combat",
-    "link": "/wiki/Unarmed_Combat",
-    "image": "/w/images/thumb/9/96/Item_icon_Unarmed_Combat.png/100px-Item_icon_Unarmed_Combat.png",
-    "killIcon": "/w/images/d/db/Killicon_unarmed_combat.png",
-    "releaseDate": "October 27, 2011 Patch(Very Scary Halloween Special)",
-    "usedBy": ["Scout"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Severed Arm",
-        "variant": "level"
-      },
-      {
-        "text": "So nice of the Spy to lend an arm...",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Batsaber",
-    "link": "/wiki/Batsaber",
-    "image": "/w/images/thumb/e/ef/Item_icon_Batsaber.png/100px-Item_icon_Batsaber.png",
-    "killIcon": "/w/images/2/29/Killicon_batsaber.png",
-    "releaseDate": "October 6, 2015 Patch(Invasion Community Update)",
-    "usedBy": ["Scout"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "\nBat",
-        "variant": "level"
-      },
-      {
-        "text": "Energy Overwhelming!\nDisintegrate your enemies!",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Sandman",
-    "link": "/wiki/Sandman",
-    "image": "/w/images/thumb/7/70/Item_icon_Sandman.png/100px-Item_icon_Sandman.png",
-    "killIcon": "/w/images/2/2c/Killicon_sandman.png",
-    "releaseDate": "February 24, 2009 Patch(Scout Update)",
-    "usedBy": ["Scout"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "Recharge (10 Seconds)\n",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 15 Bat",
-        "variant": "level"
-      },
-      {
-        "text": "Alt-Fire: Launches a ball that slows opponents",
-        "variant": "positive"
-      },
-      {
-        "text": "-15 max health on wearer",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Candy Cane",
-    "link": "/wiki/Candy_Cane",
-    "image": "/w/images/thumb/0/05/Item_icon_Candy_Cane.png/100px-Item_icon_Candy_Cane.png",
-    "killIcon": "/w/images/d/d1/Killicon_candy_cane.png",
-    "releaseDate": "December 17, 2010 Patch(Australian Christmas)",
-    "usedBy": ["Scout"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 25 Bat",
-        "variant": "level"
-      },
-      {
-        "text": "On Kill: A small health pack is dropped",
-        "variant": "positive"
-      },
-      {
-        "text": "25% explosive damage vulnerability on wearer",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Boston Basher",
-    "link": "/wiki/Boston_Basher",
-    "image": "/w/images/thumb/b/b5/Item_icon_Boston_Basher.png/100px-Item_icon_Boston_Basher.png",
-    "killIcon": "/w/images/f/f1/Killicon_boston_basher.png",
-    "releaseDate": "December 17, 2010 Patch(Australian Christmas)",
-    "usedBy": ["Scout"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 25 Bat",
-        "variant": "level"
-      },
-      {
-        "text": "On Hit: Bleed for 5 seconds",
-        "variant": "positive"
-      },
-      {
-        "text": "On Miss: Hit yourself. Idiot.",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Three-Rune Blade",
-    "link": "/wiki/Three-Rune_Blade",
-    "image": "/w/images/thumb/f/f6/Item_icon_Three-Rune_Blade.png/100px-Item_icon_Three-Rune_Blade.png",
-    "killIcon": "/w/images/9/9d/Killicon_three-rune_blade.png",
-    "releaseDate": "May 12, 2011 Patch",
-    "usedBy": ["Scout"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Genuine"],
-    "attributes": [
-      {
-        "text": "Level 10 Sword",
-        "variant": "level"
-      },
-      {
-        "text": "On Hit: Bleed for 5 seconds",
-        "variant": "positive"
-      },
-      {
-        "text": "On Miss: Hit yourself. Idiot.",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Sun-on-a-Stick",
-    "link": "/wiki/Sun-on-a-Stick",
-    "image": "/w/images/thumb/0/06/Item_icon_Sun-on-a-Stick.png/100px-Item_icon_Sun-on-a-Stick.png",
-    "killIcon": "/w/images/0/00/Killicon_sun-on-a-stick.png",
-    "releaseDate": "February 3, 2011 Patch",
-    "usedBy": ["Scout"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Genuine", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 RIFT Fire Mace",
-        "variant": "level"
-      },
-      {
-        "text": "100% critical hit vs burning players",
-        "variant": "positive"
-      },
-      {
-        "text": "+25% fire damage resistance while deployed",
-        "variant": "positive"
-      },
-      {
-        "text": "-25% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "Spiky end goes into other man.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Fan O'War",
-    "link": "/wiki/Fan_O%27War",
-    "image": "/w/images/thumb/f/f4/Item_icon_Fan_O%27War.png/100px-Item_icon_Fan_O%27War.png",
-    "killIcon": "/w/images/6/65/Killicon_fan_o%27war.png",
-    "releaseDate": "March 10, 2011 Patch(Shogun Pack)",
-    "usedBy": ["Scout"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Genuine", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Gunbai",
-        "variant": "level"
-      },
-      {
-        "text": "Crits whenever it would normally mini-crit",
-        "variant": "positive"
-      },
-      {
-        "text": "On Hit: One target at a time is Marked-For-Death, causing all damage taken to be mini-crits",
-        "variant": "positive"
-      },
-      {
-        "text": "-75% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "Winds of Gravel Pit\nScout brings on his deadly fan!\nYou are Marked-For-Death",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Atomizer",
-    "link": "/wiki/Atomizer",
-    "image": "/w/images/thumb/2/29/Item_icon_Atomizer.png/100px-Item_icon_Atomizer.png",
-    "killIcon": "/w/images/b/b1/Killicon_atomizer.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Scout"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Bat",
-        "variant": "level"
-      },
-      {
-        "text": "Grants Triple Jump while deployed.\nMelee attacks mini-crit while airborne.",
-        "variant": "positive"
-      },
-      {
-        "text": "-15% damage vs players",
-        "variant": "negative"
-      },
-      {
-        "text": "This weapon deploys 50% slower",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Wrap Assassin",
-    "link": "/wiki/Wrap_Assassin",
-    "image": "/w/images/thumb/6/6b/Item_icon_Wrap_Assassin.png/100px-Item_icon_Wrap_Assassin.png",
-    "killIcon": "/w/images/7/79/Killicon_wrap_assassin.png",
-    "releaseDate": "December 15, 2011 Patch(Australian Christmas 2011)",
-    "usedBy": ["Scout"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 15 Bat",
-        "variant": "level"
-      },
-      {
-        "text": "+25% increase in recharge rate",
-        "variant": "positive"
-      },
-      {
-        "text": "Alt-Fire: Launches a festive ornament that shatters causing bleed",
-        "variant": "positive"
-      },
-      {
-        "text": "-65% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "These lovely festive ornaments are so beautifully crafted, your enemies are going to want to see them close up. Indulge them by batting those fragile glass bulbs into their eyes at 90 mph.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Rocket Launcher",
-    "link": "/wiki/Rocket_Launcher",
-    "image": "/w/images/thumb/f/fe/Item_icon_Rocket_Launcher.png/100px-Item_icon_Rocket_Launcher.png",
-    "killIcon": "/w/images/8/8c/Killicon_rocket_launcher.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Soldier"],
-    "slot": ["Primary"],
-    "ammoLoaded": "4",
-    "ammoCarried": "20  / 36",
-    "reloadType": "Single\n  ",
-    "qualities": ["Normal", "Unique", "Strange", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 Rocket Launcher",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Original",
-    "link": "/wiki/Original",
-    "image": "/w/images/thumb/8/88/Item_icon_Original.png/100px-Item_icon_Original.png",
-    "killIcon": "/w/images/e/e0/Killicon_original.png",
-    "releaseDate": "August 3, 2011 Patch",
-    "usedBy": ["Soldier"],
-    "slot": ["Primary"],
-    "ammoLoaded": "4",
-    "ammoCarried": "20",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Genuine", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Rocket Launcher",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Direct Hit",
-    "link": "/wiki/Direct_Hit",
-    "image": "/w/images/thumb/e/e7/Item_icon_Direct_Hit.png/100px-Item_icon_Direct_Hit.png",
-    "killIcon": "/w/images/1/16/Killicon_direct_hit.png",
-    "releaseDate": "December 17, 2009 Patch(WAR! Update)",
-    "usedBy": ["Soldier"],
-    "slot": ["Primary"],
-    "ammoLoaded": "4",
-    "ammoCarried": "20",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 Rocket Launcher",
-        "variant": "level"
-      },
-      {
-        "text": "+25% damage bonus",
-        "variant": "positive"
-      },
-      {
-        "text": "+80% projectile speed",
-        "variant": "positive"
-      },
-      {
-        "text": "Mini-crits targets launched airborne by explosions, grapple hooks or rocket packs",
-        "variant": "positive"
-      },
-      {
-        "text": "-70% explosion radius",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Black Box",
-    "link": "/wiki/Black_Box",
-    "image": "/w/images/thumb/d/d2/Item_icon_Black_Box.png/100px-Item_icon_Black_Box.png",
-    "killIcon": "/w/images/5/56/Killicon_black_box.png",
-    "releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
-    "usedBy": ["Soldier"],
-    "slot": ["Primary"],
-    "ammoLoaded": "3",
-    "ammoCarried": "20",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 5 Rocket Launcher",
-        "variant": "level"
-      },
-      {
-        "text": "On Hit: Gain up to +20 health per attack",
-        "variant": "positive"
-      },
-      {
-        "text": "-25% clip size",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Rocket Jumper",
-    "link": "/wiki/Rocket_Jumper",
-    "image": "/w/images/thumb/5/53/Item_icon_Rocket_Jumper.png/100px-Item_icon_Rocket_Jumper.png",
-    "killIcon": null,
-    "releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
-    "usedBy": ["Soldier"],
-    "slot": ["Primary"],
-    "ammoLoaded": "4",
-    "ammoCarried": "60",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 Rocket Launcher",
-        "variant": "level"
-      },
-      {
-        "text": "+200% max primary ammo on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "No self inflicted blast damage taken",
-        "variant": "positive"
-      },
-      {
-        "text": "-100% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "Wearer cannot carry the intelligence briefcase or PASS Time JACK",
-        "variant": "negative"
-      },
-      {
-        "text": "A special rocket launcher for learning\nrocket jump tricks and patterns.\nThis weapon deals ZERO damage.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Liberty Launcher",
-    "link": "/wiki/Liberty_Launcher",
-    "image": "/w/images/thumb/2/24/Item_icon_Liberty_Launcher.png/100px-Item_icon_Liberty_Launcher.png",
-    "killIcon": "/w/images/7/77/Killicon_liberty_launcher.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Soldier"],
-    "slot": ["Primary"],
-    "ammoLoaded": "5",
-    "ammoCarried": "20",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 25 Rocket Launcher",
-        "variant": "level"
-      },
-      {
-        "text": "+25% clip size",
-        "variant": "positive"
-      },
-      {
-        "text": "+40% projectile speed",
-        "variant": "positive"
-      },
-      {
-        "text": "-25% blast damage from rocket jumps",
-        "variant": "positive"
-      },
-      {
-        "text": "-25% damage penalty",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Cow Mangler 5000",
-    "link": "/wiki/Cow_Mangler_5000",
-    "image": "/w/images/thumb/4/46/Item_icon_Cow_Mangler_5000.png/100px-Item_icon_Cow_Mangler_5000.png",
-    "killIcon": "/w/images/9/94/Killicon_cow_mangler_5000.png",
-    "releaseDate": "July 20, 2011 Patch(Dr. Grordbort's Victory Pack Update)",
-    "usedBy": ["Soldier"],
-    "slot": ["Primary"],
-    "ammoLoaded": "4",
-    "ammoCarried": "Unlimited",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 30 Focused Wave Projector",
-        "variant": "level"
-      },
-      {
-        "text": "Does not require ammo",
-        "variant": "positive"
-      },
-      {
-        "text": "Alt-Fire: A charged shot that\nmini-crits players, sets them on fire\nand disables buildings for 4 sec",
-        "variant": "positive"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "Deals only 20% damage to buildings",
-        "variant": "negative"
-      },
-      {
-        "text": "Minicrits whenever it would normally crit",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Beggar's Bazooka",
-    "link": "/wiki/Beggar%27s_Bazooka",
-    "image": "/w/images/thumb/7/77/Item_icon_Beggar%27s_Bazooka.png/100px-Item_icon_Beggar%27s_Bazooka.png",
-    "killIcon": "/w/images/7/7d/Killicon_beggar%27s_bazooka.png",
-    "releaseDate": "June 27, 2012 Patch(Pyromania Update)",
-    "usedBy": ["Soldier"],
-    "slot": ["Primary"],
-    "ammoLoaded": "0",
-    "ammoCarried": "20",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Rocket Launcher",
-        "variant": "level"
-      },
-      {
-        "text": "Hold Fire to load up to three rockets\nRelease Fire to unleash the barrage",
-        "variant": "positive"
-      },
-      {
-        "text": "-20% explosion radius",
-        "variant": "negative"
-      },
-      {
-        "text": "+3 degrees random projectile deviation",
-        "variant": "negative"
-      },
-      {
-        "text": "Overloading the chamber will cause a misfire",
-        "variant": "negative"
-      },
-      {
-        "text": "No ammo from dispensers when active",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Air Strike",
-    "link": "/wiki/Air_Strike",
-    "image": "/w/images/thumb/f/f8/Item_icon_Air_Strike.png/100px-Item_icon_Air_Strike.png",
-    "killIcon": "/w/images/d/dc/Killicon_air_strike.png",
-    "releaseDate": "June 18, 2014 Patch(Love & War Update)",
-    "usedBy": ["Soldier"],
-    "slot": ["Primary"],
-    "ammoLoaded": "4-8",
-    "ammoCarried": "20",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Rocket Launcher",
-        "variant": "level"
-      },
-      {
-        "text": "-15% blast damage from rocket jumps",
-        "variant": "positive"
-      },
-      {
-        "text": "Increased attack speed and smaller blast radius while blast jumping",
-        "variant": "positive"
-      },
-      {
-        "text": "Clip size increased on kill",
-        "variant": "positive"
-      },
-      {
-        "text": "-15% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "-10% explosion radius",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Shotgun",
-    "link": "/wiki/Shotgun",
-    "image": "/w/images/thumb/5/5f/Item_icon_Shotgun.png/100px-Item_icon_Shotgun.png",
-    "killIcon": "/w/images/6/61/Killicon_shotgun.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Engineer", "Soldier", "Pyro", "Heavy"],
-    "slot": ["Primary", "Secondary"],
-    "ammoLoaded": "6",
-    "ammoCarried": "32",
-    "reloadType": "Single\n  ",
-    "qualities": ["Normal", "Unique", "Strange", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 Shotgun",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Reserve Shooter",
-    "link": "/wiki/Reserve_Shooter",
-    "image": "/w/images/thumb/3/34/Item_icon_Reserve_Shooter.png/100px-Item_icon_Reserve_Shooter.png",
-    "killIcon": "/w/images/6/68/Killicon_reserve_shooter.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Soldier", "Pyro"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "4",
-    "ammoCarried": "32",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 10 Shotgun",
-        "variant": "level"
-      },
-      {
-        "text": "Mini-crits targets launched airborne by explosions, grapple hooks or rocket packs",
-        "variant": "positive"
-      },
-      {
-        "text": "This weapon deploys 20% faster",
-        "variant": "positive"
-      },
-      {
-        "text": "-34% clip size",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Buff Banner",
-    "link": "/wiki/Buff_Banner",
-    "image": "/w/images/thumb/7/7c/Item_icon_Buff_Banner.png/100px-Item_icon_Buff_Banner.png",
-    "killIcon": null,
-    "releaseDate": "December 17, 2009 Patch(WAR! Update)",
-    "usedBy": ["Soldier"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Battle Banner",
-        "variant": "level"
-      },
-      {
-        "text": "Provides an offensive buff that causes\nnearby team members to do mini-crits.\nRage increases through damage done.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Gunboats",
-    "link": "/wiki/Gunboats",
-    "image": "/w/images/thumb/0/0c/Item_icon_Gunboats.png/100px-Item_icon_Gunboats.png",
-    "killIcon": null,
-    "releaseDate": "December 17, 2009 Patch(WAR! Update)",
-    "usedBy": ["Soldier"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Boots",
-        "variant": "level"
-      },
-      {
-        "text": "-60% blast damage from rocket jumps",
-        "variant": "positive"
-      }
-    ]
-  },
-  {
-    "name": "Battalion's Backup",
-    "link": "/wiki/Battalion%27s_Backup",
-    "image": "/w/images/thumb/d/d8/Item_icon_Battalion%27s_Backup.png/100px-Item_icon_Battalion%27s_Backup.png",
-    "killIcon": null,
-    "releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
-    "usedBy": ["Soldier"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Battle Banner",
-        "variant": "level"
-      },
-      {
-        "text": "+20 max health on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "Provides a defensive buff that protects\nnearby team members from crits,\nincoming sentry damage by 50%\nand 35% from all other sources.\nRage increases through damage done.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Concheror",
-    "link": "/wiki/Concheror",
-    "image": "/w/images/thumb/7/7e/Item_icon_Concheror.png/100px-Item_icon_Concheror.png",
-    "killIcon": null,
-    "releaseDate": "March 10, 2011 Patch(Shogun Pack)",
-    "usedBy": ["Soldier"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Genuine", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Sashimono",
-        "variant": "level"
-      },
-      {
-        "text": "+4 health regenerated per second on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "Provides group speed buff\nwith damage done giving health.\nGain rage with damage.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Mantreads",
-    "link": "/wiki/Mantreads",
-    "image": "/w/images/thumb/6/6a/Item_icon_Mantreads.png/100px-Item_icon_Mantreads.png",
-    "killIcon": "/w/images/a/ac/Killicon_mantreads.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Soldier"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Boots",
-        "variant": "level"
-      },
-      {
-        "text": "-75% reduction in push force taken from damage",
-        "variant": "positive"
-      },
-      {
-        "text": "Deals 3x falling damage to the player you land on",
-        "variant": "positive"
-      },
-      {
-        "text": "-75% reduction in airblast vulnerability",
-        "variant": "positive"
-      },
-      {
-        "text": "200% increased air control when blast jumping",
-        "variant": "positive"
-      }
-    ]
-  },
-  {
-    "name": "Righteous Bison",
-    "link": "/wiki/Righteous_Bison",
-    "image": "/w/images/thumb/1/1d/Item_icon_Righteous_Bison.png/100px-Item_icon_Righteous_Bison.png",
-    "killIcon": "/w/images/a/a4/Killicon_righteous_bison.png",
-    "releaseDate": "July 20, 2011 Patch(Dr. Grordbort's Victory Pack Update)",
-    "usedBy": ["Soldier"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "4",
-    "ammoCarried": "Unlimited",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Genuine", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 30 Indivisible Particle Smasher",
-        "variant": "level"
-      },
-      {
-        "text": "Does not require ammo",
-        "variant": "positive"
-      },
-      {
-        "text": "Projectile penetrates enemy targets",
-        "variant": "positive"
-      },
-      {
-        "text": "Projectile cannot be deflected",
-        "variant": "positive"
-      },
-      {
-        "text": "Deals only 20% damage to buildings",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "B.A.S.E. Jumper",
-    "link": "/wiki/B.A.S.E._Jumper",
-    "image": "/w/images/thumb/b/b2/Item_icon_B.A.S.E._Jumper.png/100px-Item_icon_B.A.S.E._Jumper.png",
-    "killIcon": null,
-    "releaseDate": "June 18, 2014 Patch(Love & War Update)",
-    "usedBy": ["Soldier", "Demoman"],
-    "slot": ["Primary", "Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Parachute",
-        "variant": "level"
-      },
-      {
-        "text": "Press 'JUMP' key in the air to deploy.\nDeployed Parachutes slow your descent.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Panic Attack",
-    "link": "/wiki/Panic_Attack",
-    "image": "/w/images/thumb/b/be/Item_icon_Panic_Attack.png/100px-Item_icon_Panic_Attack.png",
-    "killIcon": "/w/images/c/c5/Killicon_panic_attack.png",
-    "releaseDate": "December 22, 2014 Patch(Smissmas 2014)",
-    "usedBy": ["Engineer", "Soldier", "Pyro", "Heavy"],
-    "slot": ["Primary", "Secondary"],
-    "ammoLoaded": "6",
-    "ammoCarried": "32",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Strange", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 - 99 Shotgun",
-        "variant": "level"
-      },
-      {
-        "text": "+50% bullets per shot",
-        "variant": "positive"
-      },
-      {
-        "text": "This weapon deploys 50% faster",
-        "variant": "positive"
-      },
-      {
-        "text": "Fires a wide, fixed shot pattern",
-        "variant": "positive"
-      },
-      {
-        "text": "-20% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "Successive shots become less accurate",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Shovel",
-    "link": "/wiki/Shovel",
-    "image": "/w/images/thumb/7/73/Item_icon_Shovel.png/100px-Item_icon_Shovel.png",
-    "killIcon": "/w/images/6/6e/Killicon_shovel.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Soldier"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Normal", "Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "Level 1 Shovel",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Equalizer",
-    "link": "/wiki/Equalizer",
-    "image": "/w/images/thumb/b/ba/Item_icon_Equalizer.png/100px-Item_icon_Equalizer.png",
-    "killIcon": "/w/images/a/a5/Killicon_equalizer.png",
-    "releaseDate": "December 17, 2009 Patch(WAR! Update)",
-    "usedBy": ["Soldier"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Pickaxe",
-        "variant": "level"
-      },
-      {
-        "text": " When weapon is active: ",
-        "variant": "neutral"
-      },
-      {
-        "text": "Damage increases as the user becomes injured",
-        "variant": "positive"
-      },
-      {
-        "text": "-90% less healing from Medic sources",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Pain Train",
-    "link": "/wiki/Pain_Train",
-    "image": "/w/images/thumb/4/4b/Item_icon_Pain_Train.png/100px-Item_icon_Pain_Train.png",
-    "killIcon": "/w/images/7/79/Killicon_pain_train.png",
-    "releaseDate": "March 18, 2010 Patch(First Community Contribution Update)",
-    "usedBy": ["Soldier", "Demoman"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Makeshift Club",
-        "variant": "level"
-      },
-      {
-        "text": "+1 capture rate on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "10% bullet damage vulnerability on wearer",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Half-Zatoichi",
-    "link": "/wiki/Half-Zatoichi",
-    "image": "/w/images/thumb/a/a9/Item_icon_Half-Zatoichi.png/100px-Item_icon_Half-Zatoichi.png",
-    "killIcon": "/w/images/9/93/Killicon_half-zatoichi.png",
-    "releaseDate": "March 10, 2011 Patch(Shogun Pack)",
-    "usedBy": ["Soldier", "Demoman"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Genuine", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Katana",
-        "variant": "level"
-      },
-      {
-        "text": " This Weapon has a large melee range and\ndeploys and holsters slower ",
-        "variant": "neutral"
-      },
-      {
-        "text": "Gain 50% of base health on kill",
-        "variant": "positive"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "Honorbound: Once drawn sheathing deals 50 damage to yourself unless it kills",
-        "variant": "negative"
-      },
-      {
-        "text": "Soldiers and Demos\nCan duel with katanas\nFor a one-hit kill",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Disciplinary Action",
-    "link": "/wiki/Disciplinary_Action",
-    "image": "/w/images/thumb/c/cf/Item_icon_Disciplinary_Action.png/100px-Item_icon_Disciplinary_Action.png",
-    "killIcon": "/w/images/1/12/Killicon_disciplinary_action.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Soldier"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 10 Riding Crop",
-        "variant": "level"
-      },
-      {
-        "text": "On Hit Teammate: Boosts both players' speed for several seconds",
-        "variant": "positive"
-      },
-      {
-        "text": "-25% damage penalty",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Market Gardener",
-    "link": "/wiki/Market_Gardener",
-    "image": "/w/images/thumb/a/ac/Item_icon_Market_Gardener.png/100px-Item_icon_Market_Gardener.png",
-    "killIcon": "/w/images/0/00/Killicon_market_gardener.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Soldier"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Shovel",
-        "variant": "level"
-      },
-      {
-        "text": "Deals crits while the wielder is rocket jumping",
-        "variant": "positive"
-      },
-      {
-        "text": "20% slower firing speed",
-        "variant": "negative"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Escape Plan",
-    "link": "/wiki/Escape_Plan",
-    "image": "/w/images/thumb/0/0c/Item_icon_Escape_Plan.png/100px-Item_icon_Escape_Plan.png",
-    "killIcon": "/w/images/d/de/Killicon_escape_plan.png",
-    "releaseDate": "June 27, 2012 Patch(Pyromania Update)",
-    "usedBy": ["Soldier"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Pickaxe",
-        "variant": "level"
-      },
-      {
-        "text": " When weapon is active: ",
-        "variant": "neutral"
-      },
-      {
-        "text": "Move speed increases as the user becomes injured",
-        "variant": "positive"
-      },
-      {
-        "text": "You are Marked-For-Death while active, and for short period after switching weapons",
-        "variant": "negative"
-      },
-      {
-        "text": "-90% less healing from Medic sources",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Flame Thrower",
-    "link": "/wiki/Flame_Thrower",
-    "image": "/w/images/thumb/e/ec/Item_icon_Flame_Thrower.png/100px-Item_icon_Flame_Thrower.png",
-    "killIcon": "/w/images/e/eb/Killicon_flame_thrower.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Pyro"],
-    "slot": ["Primary"],
-    "ammoLoaded": "200",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Normal", "Unique", "Strange", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 Flame Thrower",
-        "variant": "level"
-      },
-      {
-        "text": "Extinguishing teammates restores 20 health",
-        "variant": "positive"
-      },
-      {
-        "text": "Afterburn reduces Medi Gun healing and resist shield effects.\nAlt-Fire: Release a blast of air that pushes enemies and projectiles and extinguishes teammates that are on fire.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Rainblower",
-    "link": "/wiki/Rainblower",
-    "image": "/w/images/thumb/3/3c/Item_icon_Rainblower.png/100px-Item_icon_Rainblower.png",
-    "killIcon": "/w/images/f/f6/Killicon_rainblower.png",
-    "releaseDate": "June 27, 2012 Patch(Pyromania Update)",
-    "usedBy": ["Pyro"],
-    "slot": ["Primary"],
-    "ammoLoaded": "200",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Flame Thrower",
-        "variant": "level"
-      },
-      {
-        "text": "On Equip: Visit Pyroland",
-        "variant": "positive"
-      },
-      {
-        "text": "Only visible in Pyroland",
-        "variant": "negative"
-      },
-      {
-        "text": "Your friends (enemies) will squeal with delight (be consumed with fire) when you cover them in sparkly rainbows (all-consuming fire). (Equips Pyrovision.)",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Nostromo Napalmer",
-    "link": "/wiki/Nostromo_Napalmer",
-    "image": "/w/images/thumb/d/d3/Item_icon_Nostromo_Napalmer.png/100px-Item_icon_Nostromo_Napalmer.png",
-    "killIcon": "/w/images/c/c4/Killicon_nostromo_napalmer.png",
-    "releaseDate": "September 17, 2014 Patch",
-    "usedBy": ["Pyro"],
-    "slot": ["Primary"],
-    "ammoLoaded": "200",
-    "ammoCarried": "N/A",
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Genuine"],
-    "attributes": [
-      {
-        "text": "Level 10 Flame Thrower",
-        "variant": "level"
-      },
-      {
-        "text": "Extinguishing teammates restores 20 health",
-        "variant": "positive"
-      }
-    ]
-  },
-  {
-    "name": "Backburner",
-    "link": "/wiki/Backburner",
-    "image": "/w/images/thumb/5/5d/Item_icon_Backburner.png/100px-Item_icon_Backburner.png",
-    "killIcon": "/w/images/3/3a/Killicon_backburner.png",
-    "releaseDate": "June 19, 2008 Patch(Pyro Update)",
-    "usedBy": ["Pyro"],
-    "slot": ["Primary"],
-    "ammoLoaded": "200",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Flame Thrower",
-        "variant": "level"
-      },
-      {
-        "text": "100% critical hits from behind",
-        "variant": "positive"
-      },
-      {
-        "text": "+150% airblast cost",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Degreaser",
-    "link": "/wiki/Degreaser",
-    "image": "/w/images/thumb/9/94/Item_icon_Degreaser.png/100px-Item_icon_Degreaser.png",
-    "killIcon": "/w/images/0/0f/Killicon_degreaser.png",
-    "releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
-    "usedBy": ["Pyro"],
-    "slot": ["Primary"],
-    "ammoLoaded": "200",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 10 Flame Thrower",
-        "variant": "level"
-      },
-      {
-        "text": "This weapon holsters 30% faster",
-        "variant": "positive"
-      },
-      {
-        "text": "This weapon deploys 60% faster",
-        "variant": "positive"
-      },
-      {
-        "text": "Extinguishing teammates restores 20 health",
-        "variant": "positive"
-      },
-      {
-        "text": "-66% afterburn damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "+25% airblast cost",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Phlogistinator",
-    "link": "/wiki/Phlogistinator",
-    "image": "/w/images/thumb/2/22/Item_icon_Phlogistinator.png/100px-Item_icon_Phlogistinator.png",
-    "killIcon": "/w/images/6/66/Killicon_phlogistinator.png",
-    "releaseDate": "December 15, 2011 Patch(Australian Christmas 2011)",
-    "usedBy": ["Pyro"],
-    "slot": ["Primary"],
-    "ammoLoaded": "200",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Flame Thrower",
-        "variant": "level"
-      },
-      {
-        "text": "Build 'Mmmph' by dealing damage.\nAlt-Fire on full 'Mmmph': Taunt to gain crit for several seconds.\nInvulnerable while 'Mmmph' taunting.",
-        "variant": "positive"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "No airblast",
-        "variant": "negative"
-      },
-      {
-        "text": "Being a revolutionary appliance capable of awakening the fire element phlogiston that exists in all combustible creatures, which is to say, all of them.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Contract",
-    "link": "/wiki/Dragon%27s_Fury",
-    "image": "/w/images/thumb/1/1f/Item_icon_Dragon%27s_Fury.png/100px-Item_icon_Dragon%27s_Fury.png",
-    "killIcon": "/w/images/2/20/Killicon_dragon%27s_fury.png",
-    "releaseDate": "October 20, 2017 Patch(Jungle Inferno Update)",
-    "usedBy": ["Pyro"],
-    "slot": ["Primary"],
-    "ammoLoaded": "40",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Flame Launcher",
-        "variant": "level"
-      },
-      {
-        "text": " Uses a shared pressure tank for Primary Fire and Alt-Fire.\n\nPrimary Fire: Launches a fast-moving projectile that briefly ignites enemies\n\nAlt-Fire: Release a blast of air that pushes enemies and projectiles, and extinguishes teammates that are on fire. ",
-        "variant": "neutral"
-      },
-      {
-        "text": "Extinguishing teammates restores 20 health",
-        "variant": "positive"
-      },
-      {
-        "text": "Deals 300% damage to burning players\n+50% re-pressurization rate on hit",
-        "variant": "positive"
-      },
-      {
-        "text": "-50% repressurization rate on Alt-Fire",
-        "variant": "negative"
-      },
-      {
-        "text": "This powerful, single-shot flamethrower rewards consecutive hits with faster reloads and bonus damage.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Flare Gun",
-    "link": "/wiki/Flare_Gun",
-    "image": "/w/images/thumb/7/7b/Item_icon_Flare_Gun.png/100px-Item_icon_Flare_Gun.png",
-    "killIcon": "/w/images/d/d4/Killicon_flare_gun.png",
-    "releaseDate": "June 19, 2008 Patch(Pyro Update)",
-    "usedBy": ["Pyro"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "16",
-    "ammoCarried": null,
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Flare Gun",
-        "variant": "level"
-      },
-      {
-        "text": "100% critical hit vs burning players",
-        "variant": "positive"
-      },
-      {
-        "text": "This weapon will reload when not active",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Detonator",
-    "link": "/wiki/Detonator",
-    "image": "/w/images/thumb/5/53/Item_icon_Detonator.png/100px-Item_icon_Detonator.png",
-    "killIcon": "/w/images/9/9e/Killicon_detonator.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Pyro"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "16",
-    "ammoCarried": null,
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 10 Flare Gun",
-        "variant": "level"
-      },
-      {
-        "text": "100% mini-crits vs burning players",
-        "variant": "positive"
-      },
-      {
-        "text": "-25% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "+50% damage to self",
-        "variant": "negative"
-      },
-      {
-        "text": "Alt-Fire: Detonate flare.\nThis weapon will reload automatically when not active.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Manmelter",
-    "link": "/wiki/Manmelter",
-    "image": "/w/images/thumb/9/9d/Item_icon_Manmelter.png/100px-Item_icon_Manmelter.png",
-    "killIcon": "/w/images/a/ad/Killicon_manmelter.png",
-    "releaseDate": "December 15, 2011 Patch(Australian Christmas 2011)",
-    "usedBy": ["Pyro"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "Unlimited",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 30 Indivisible Particle Smasher",
-        "variant": "level"
-      },
-      {
-        "text": "+50% projectile speed",
-        "variant": "positive"
-      },
-      {
-        "text": "Does not require ammo",
-        "variant": "positive"
-      },
-      {
-        "text": "Alt-Fire: Extinguish teammates to gain guaranteed critical hits",
-        "variant": "positive"
-      },
-      {
-        "text": "Extinguishing teammates restores 20 health",
-        "variant": "positive"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "This weapon will reload automatically when not active.\n\nBeing a device that flouts conventional scientific consensus that the molecules composing the human body must be arranged \"just so\", and not, for example, across a square-mile radius.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Scorch Shot",
-    "link": "/wiki/Scorch_Shot",
-    "image": "/w/images/thumb/b/be/Item_icon_Scorch_Shot.png/100px-Item_icon_Scorch_Shot.png",
-    "killIcon": "/w/images/2/20/Killicon_scorch_shot.png",
-    "releaseDate": "June 27, 2012 Patch(Pyromania Update)",
-    "usedBy": ["Pyro"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "16",
-    "ammoCarried": null,
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 10 Flare Gun",
-        "variant": "level"
-      },
-      {
-        "text": "100% mini-crits vs burning players",
-        "variant": "positive"
-      },
-      {
-        "text": "Flare knocks back target on hit\nand explodes when it hits the ground.\nIncreased knock back on burning players",
-        "variant": "positive"
-      },
-      {
-        "text": "-35% self damage force",
-        "variant": "negative"
-      },
-      {
-        "text": "-35% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "This weapon will reload automatically when not active.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Fire Axe",
-    "link": "/wiki/Fire_Axe",
-    "image": "/w/images/thumb/9/9f/Item_icon_Fire_Axe.png/100px-Item_icon_Fire_Axe.png",
-    "killIcon": "/w/images/d/da/Killicon_fire_axe.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Pyro"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Normal", "Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "Level 1 Fire Axe",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Lollichop",
-    "link": "/wiki/Lollichop",
-    "image": "/w/images/thumb/6/65/Item_icon_Lollichop.png/100px-Item_icon_Lollichop.png",
-    "killIcon": "/w/images/4/44/Killicon_lollichop.png",
-    "releaseDate": "June 27, 2012 Patch(Pyromania Update)",
-    "usedBy": ["Pyro"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Fire Axe",
-        "variant": "level"
-      },
-      {
-        "text": "On Equip: Visit Pyroland",
-        "variant": "positive"
-      },
-      {
-        "text": "Only visible in Pyroland",
-        "variant": "negative"
-      },
-      {
-        "text": "Fill (split) your buddies' tummies (skulls) with delicious candy (cold steel) with this oversized sugary treat. (Equips Pyrovision.)",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Axtinguisher",
-    "link": "/wiki/Axtinguisher",
-    "image": "/w/images/thumb/c/c9/Item_icon_Axtinguisher.png/100px-Item_icon_Axtinguisher.png",
-    "killIcon": "/w/images/5/59/Killicon_axtinguisher.png",
-    "releaseDate": "June 19, 2008 Patch(Pyro Update)",
-    "usedBy": ["Pyro"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Fire Axe",
-        "variant": "level"
-      },
-      {
-        "text": "Mini-crits burning targets and extinguishes them.\nDamage increases based on remaining duration of afterburn\nKilling blows on burning players grant a speed boost.",
-        "variant": "positive"
-      },
-      {
-        "text": "-33% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "This weapon holsters 35% slower",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Postal Pummeler",
-    "link": "/wiki/Postal_Pummeler",
-    "image": "/w/images/thumb/2/2d/Item_icon_Postal_Pummeler.png/100px-Item_icon_Postal_Pummeler.png",
-    "killIcon": "/w/images/a/a3/Killicon_postal_pummeler.png",
-    "releaseDate": "July 1, 2011 Patch(Summer Camp Sale)",
-    "usedBy": ["Pyro"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Mailbox",
-        "variant": "level"
-      },
-      {
-        "text": "Mini-crits burning targets and extinguishes them.\nDamage increases based on remaining duration of afterburn\nKilling blows on burning players grant a speed boost.",
-        "variant": "positive"
-      },
-      {
-        "text": "-33% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "This weapon holsters 35% slower",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Homewrecker",
-    "link": "/wiki/Homewrecker",
-    "image": "/w/images/thumb/4/4a/Item_icon_Homewrecker.png/100px-Item_icon_Homewrecker.png",
-    "killIcon": "/w/images/7/72/Killicon_homewrecker.png",
-    "releaseDate": "March 18, 2010 Patch(First Community Contribution Update)",
-    "usedBy": ["Pyro"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Sledgehammer",
-        "variant": "level"
-      },
-      {
-        "text": "+100% damage vs buildings",
-        "variant": "positive"
-      },
-      {
-        "text": "Damage removes Sappers",
-        "variant": "positive"
-      },
-      {
-        "text": "-25% damage vs players",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Maul",
-    "link": "/wiki/Maul",
-    "image": "/w/images/thumb/2/2e/Item_icon_Maul.png/100px-Item_icon_Maul.png",
-    "killIcon": "/w/images/9/91/Killicon_maul.png",
-    "releaseDate": "June 3, 2011 Patch",
-    "usedBy": ["Pyro"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Genuine"],
-    "attributes": [
-      {
-        "text": "Level 5 Sledgehammer",
-        "variant": "level"
-      },
-      {
-        "text": "+100% damage vs buildings",
-        "variant": "positive"
-      },
-      {
-        "text": "Damage removes Sappers",
-        "variant": "positive"
-      },
-      {
-        "text": "-25% damage vs players",
-        "variant": "negative"
-      },
-      {
-        "text": "Packs a devastating punch with a hint of Mars dust.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Powerjack",
-    "link": "/wiki/Powerjack",
-    "image": "/w/images/thumb/c/cf/Item_icon_Powerjack.png/100px-Item_icon_Powerjack.png",
-    "killIcon": "/w/images/5/51/Killicon_powerjack.png",
-    "releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
-    "usedBy": ["Pyro"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 5 Sledgehammer",
-        "variant": "level"
-      },
-      {
-        "text": " When weapon is active: ",
-        "variant": "neutral"
-      },
-      {
-        "text": "+15% faster move speed on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "+25 health restored on kill",
-        "variant": "positive"
-      },
-      {
-        "text": "20% damage vulnerability on wearer",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Back Scratcher",
-    "link": "/wiki/Back_Scratcher",
-    "image": "/w/images/thumb/4/48/Item_icon_Back_Scratcher.png/100px-Item_icon_Back_Scratcher.png",
-    "killIcon": "/w/images/f/ff/Killicon_back_scratcher.png",
-    "releaseDate": "December 17, 2010 Patch(Australian Christmas)",
-    "usedBy": ["Pyro"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 10 Garden Rake",
-        "variant": "level"
-      },
-      {
-        "text": "+25% damage bonus",
-        "variant": "positive"
-      },
-      {
-        "text": "+50% health from packs on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "-75% health from healers on wearer",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Sharpened Volcano Fragment",
-    "link": "/wiki/Sharpened_Volcano_Fragment",
-    "image": "/w/images/thumb/a/ac/Item_icon_Sharpened_Volcano_Fragment.png/100px-Item_icon_Sharpened_Volcano_Fragment.png",
-    "killIcon": "/w/images/8/80/Killicon_sharpened_volcano_fragment.png",
-    "releaseDate": "February 3, 2011 Patch",
-    "usedBy": ["Pyro"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Genuine", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 RIFT Fire Axe",
-        "variant": "level"
-      },
-      {
-        "text": "On Hit: target is engulfed in flames",
-        "variant": "positive"
-      },
-      {
-        "text": "-20% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "Improves upon Mother Nature's original design for volcanos by increasing portability. Modern science is unable to explain exactly where the lava is coming from.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Third Degree",
-    "link": "/wiki/Third_Degree",
-    "image": "/w/images/thumb/9/91/Item_icon_Third_Degree.png/100px-Item_icon_Third_Degree.png",
-    "killIcon": "/w/images/2/22/Killicon_third_degree.png",
-    "releaseDate": "December 15, 2011 Patch(Australian Christmas 2011)",
-    "usedBy": ["Pyro"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Fire Axe",
-        "variant": "level"
-      },
-      {
-        "text": "All players connected via Medigun beams are hit",
-        "variant": "positive"
-      },
-      {
-        "text": "Being a boon to tree-fellers, backwoodsmen and atom-splitters the world over, this miraculous matter-hewing device burns each individual molecule as it cleaves it.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Neon Annihilator",
-    "link": "/wiki/Neon_Annihilator",
-    "image": "/w/images/thumb/e/e9/Item_icon_Neon_Annihilator.png/100px-Item_icon_Neon_Annihilator.png",
-    "killIcon": "/w/images/5/5b/Killicon_neon_annihilator.png",
-    "releaseDate": "August 2, 2012 Patch(Triad Pack)",
-    "usedBy": ["Pyro"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Genuine", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Sign",
-        "variant": "level"
-      },
-      {
-        "text": "Damage removes Sappers",
-        "variant": "positive"
-      },
-      {
-        "text": "100% critical hit vs wet players",
-        "variant": "positive"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "-20% damage vs players",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Grenade Launcher",
-    "link": "/wiki/Grenade_Launcher",
-    "image": "/w/images/thumb/e/e6/Item_icon_Grenade_Launcher.png/100px-Item_icon_Grenade_Launcher.png",
-    "killIcon": "/w/images/d/db/Killicon_grenade_launcher.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Demoman"],
-    "slot": ["Primary"],
-    "ammoLoaded": "4  / 6",
-    "ammoCarried": "16  / 30",
-    "reloadType": "Single\n  ",
-    "qualities": ["Normal", "Unique", "Strange", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 Grenade Launcher",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Loch-n-Load",
-    "link": "/wiki/Loch-n-Load",
-    "image": "/w/images/thumb/6/62/Item_icon_Loch-n-Load.png/100px-Item_icon_Loch-n-Load.png",
-    "killIcon": "/w/images/6/6a/Killicon_loch-n-load.png",
-    "releaseDate": "December 17, 2010 Patch(Australian Christmas)",
-    "usedBy": ["Demoman"],
-    "slot": ["Primary"],
-    "ammoLoaded": "3",
-    "ammoCarried": "16",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 10 Grenade Launcher",
-        "variant": "level"
-      },
-      {
-        "text": "+20% damage vs buildings",
-        "variant": "positive"
-      },
-      {
-        "text": "+25% projectile speed",
-        "variant": "positive"
-      },
-      {
-        "text": "-25% clip size",
-        "variant": "negative"
-      },
-      {
-        "text": "-25% explosion radius",
-        "variant": "negative"
-      },
-      {
-        "text": "Launched bombs shatter on surfaces",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Ali Baba's Wee Booties",
-    "link": "/wiki/Ali_Baba%27s_Wee_Booties",
-    "image": "/w/images/thumb/a/a4/Item_icon_Ali_Baba%27s_Wee_Booties.png/100px-Item_icon_Ali_Baba%27s_Wee_Booties.png",
-    "killIcon": null,
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Demoman"],
-    "slot": ["Primary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Boots",
-        "variant": "level"
-      },
-      {
-        "text": "+25 max health on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "+200% increase in turning control while charging",
-        "variant": "positive"
-      },
-      {
-        "text": "+10% faster move speed on wearer (shield required)",
-        "variant": "positive"
-      },
-      {
-        "text": "Melee kills refill 25% of your charge meter",
-        "variant": "positive"
-      }
-    ]
-  },
-  {
-    "name": "Bootlegger",
-    "link": "/wiki/Bootlegger",
-    "image": "/w/images/thumb/4/4c/Item_icon_Bootlegger.png/100px-Item_icon_Bootlegger.png",
-    "killIcon": null,
-    "releaseDate": "October 13, 2011 Patch(Manniversary Update & Sale)",
-    "usedBy": ["Demoman"],
-    "slot": ["Primary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Boots",
-        "variant": "level"
-      },
-      {
-        "text": "+25 max health on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "+200% increase in turning control while charging",
-        "variant": "positive"
-      },
-      {
-        "text": "+10% faster move speed on wearer (shield required)",
-        "variant": "positive"
-      },
-      {
-        "text": "Melee kills refill 25% of your charge meter",
-        "variant": "positive"
-      },
-      {
-        "text": "Amaze your friends! Impress women! Walk with a limp for life! It's grotesque!",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Loose Cannon",
-    "link": "/wiki/Loose_Cannon",
-    "image": "/w/images/thumb/7/70/Item_icon_Loose_Cannon.png/100px-Item_icon_Loose_Cannon.png",
-    "killIcon": "/w/images/e/e1/Killicon_loose_cannon.png",
-    "releaseDate": "December 20, 2012 Patch(Mecha Update)",
-    "usedBy": ["Demoman"],
-    "slot": ["Primary"],
-    "ammoLoaded": "4",
-    "ammoCarried": "16",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 10 Grenade Launcher",
-        "variant": "level"
-      },
-      {
-        "text": " Cannonballs have a fuse time of 1 second; fuses can be primed to explode earlier by holding down the fire key ",
-        "variant": "neutral"
-      },
-      {
-        "text": "+20% projectile speed",
-        "variant": "positive"
-      },
-      {
-        "text": "Cannonballs push players back on impact",
-        "variant": "positive"
-      },
-      {
-        "text": "Cannonballs do not explode on impact",
-        "variant": "negative"
-      },
-      {
-        "text": "Double Donk! Bomb explosions after a cannon ball impact will deal mini-crits to impact victims",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Iron Bomber",
-    "link": "/wiki/Iron_Bomber",
-    "image": "/w/images/thumb/c/cd/Item_icon_Iron_Bomber.png/100px-Item_icon_Iron_Bomber.png",
-    "killIcon": "/w/images/3/34/Killicon_iron_bomber.png",
-    "releaseDate": "December 22, 2014 Patch(Smissmas 2014)",
-    "usedBy": ["Demoman"],
-    "slot": ["Primary"],
-    "ammoLoaded": "4",
-    "ammoCarried": "16",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Strange", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 - 99 Grenade Launcher",
-        "variant": "level"
-      },
-      {
-        "text": "Grenades have very little bounce and roll",
-        "variant": "positive"
-      },
-      {
-        "text": "-30% fuse time on grenades",
-        "variant": "positive"
-      },
-      {
-        "text": "-15% explosion radius",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Stickybomb Launcher",
-    "link": "/wiki/Stickybomb_Launcher",
-    "image": "/w/images/thumb/7/7c/Item_icon_Stickybomb_Launcher.png/100px-Item_icon_Stickybomb_Launcher.png",
-    "killIcon": "/w/images/0/08/Killicon_stickybomb_launcher.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Demoman"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "8",
-    "ammoCarried": "24 / 40",
-    "reloadType": "Single\n  ",
-    "qualities": ["Normal", "Unique", "Strange", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 Stickybomb Launcher",
-        "variant": "level"
-      },
-      {
-        "text": "Alt-Fire: Detonate all stickybombs",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Scottish Resistance",
-    "link": "/wiki/Scottish_Resistance",
-    "image": "/w/images/thumb/2/2c/Item_icon_Scottish_Resistance.png/100px-Item_icon_Scottish_Resistance.png",
-    "killIcon": "/w/images/1/1b/Killicon_scottish_resistance.png",
-    "releaseDate": "December 17, 2009 Patch(WAR! Update)",
-    "usedBy": ["Demoman"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "8",
-    "ammoCarried": "36",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Stickybomb Launcher",
-        "variant": "level"
-      },
-      {
-        "text": "+25% faster firing speed",
-        "variant": "positive"
-      },
-      {
-        "text": "+50% max secondary ammo on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "+6 max pipebombs out",
-        "variant": "positive"
-      },
-      {
-        "text": "Detonates stickybombs near the crosshair and directly under your feet",
-        "variant": "positive"
-      },
-      {
-        "text": "Able to destroy enemy stickybombs",
-        "variant": "positive"
-      },
-      {
-        "text": "0.8 sec slower bomb arm time",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Chargin' Targe",
-    "link": "/wiki/Chargin%27_Targe",
-    "image": "/w/images/thumb/7/7a/Item_icon_Chargin%27_Targe.png/100px-Item_icon_Chargin%27_Targe.png",
-    "killIcon": "/w/images/3/38/Killicon_chargin%27_targe.png",
-    "releaseDate": "December 17, 2009 Patch(WAR! Update)",
-    "usedBy": ["Demoman"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "Recharge\n  ",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 - 99 Shield",
-        "variant": "level"
-      },
-      {
-        "text": "+50% fire damage resistance on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "+30% explosive damage resistance on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "Alt-Fire: Charge toward your enemies and remove debuffs.\nGain a critical melee strike after impacting an enemy at distance.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Sticky Jumper",
-    "link": "/wiki/Sticky_Jumper",
-    "image": "/w/images/thumb/5/56/Item_icon_Sticky_Jumper.png/100px-Item_icon_Sticky_Jumper.png",
-    "killIcon": null,
-    "releaseDate": "October 27, 2010 Patch(Scream Fortress Update)",
-    "usedBy": ["Demoman"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "8",
-    "ammoCarried": "72",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 Stickybomb Launcher",
-        "variant": "level"
-      },
-      {
-        "text": "+200% max secondary ammo on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "No self inflicted blast damage taken",
-        "variant": "positive"
-      },
-      {
-        "text": "-100% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "-6 max pipebombs out",
-        "variant": "negative"
-      },
-      {
-        "text": "Wearer cannot carry the intelligence briefcase or PASS Time JACK",
-        "variant": "negative"
-      },
-      {
-        "text": "A special no-damage stickybomb launcher for learning stickybomb jump tricks and patterns.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Splendid Screen",
-    "link": "/wiki/Splendid_Screen",
-    "image": "/w/images/thumb/c/c3/Item_icon_Splendid_Screen.png/100px-Item_icon_Splendid_Screen.png",
-    "killIcon": "/w/images/f/fb/Killicon_splendid_screen.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Demoman"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "Recharge\n  ",
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Shield",
-        "variant": "level"
-      },
-      {
-        "text": "+20% fire damage resistance on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "+20% explosive damage resistance on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "+70% increase in charge impact damage",
-        "variant": "positive"
-      },
-      {
-        "text": "+50% increase in charge recharge rate",
-        "variant": "positive"
-      },
-      {
-        "text": "Alt-Fire: Charge toward your enemies and remove debuffs.\nGain a critical melee strike after impacting an enemy.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Tide Turner",
-    "link": "/wiki/Tide_Turner",
-    "image": "/w/images/thumb/c/cd/Item_icon_Tide_Turner.png/100px-Item_icon_Tide_Turner.png",
-    "killIcon": "/w/images/f/fd/Killicon_tide_turner.png",
-    "releaseDate": "June 18, 2014 Patch(Love & War Update)",
-    "usedBy": ["Demoman"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "Recharge\n  ",
-    "qualities": ["Unique", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Shield",
-        "variant": "level"
-      },
-      {
-        "text": "+15% fire damage resistance on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "+15% explosive damage resistance on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "Full turning control while charging",
-        "variant": "positive"
-      },
-      {
-        "text": "Melee kills refill 75% of your charge meter",
-        "variant": "positive"
-      },
-      {
-        "text": "Taking damage while shield charging reduces remaining charging time",
-        "variant": "negative"
-      },
-      {
-        "text": "Alt-Fire: Charge toward your enemies and remove debuffs.\nGain a mini-crit melee strike after impacting an enemy at distance.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Quickiebomb Launcher",
-    "link": "/wiki/Quickiebomb_Launcher",
-    "image": "/w/images/thumb/f/f9/Item_icon_Quickiebomb_Launcher.png/100px-Item_icon_Quickiebomb_Launcher.png",
-    "killIcon": "/w/images/6/6a/Killicon_quickiebomb_launcher.png",
-    "releaseDate": "December 22, 2014 Patch(Smissmas 2014)",
-    "usedBy": ["Demoman"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "4",
-    "ammoCarried": "24",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "Level 1 - 99 Stickybomb Launcher",
-        "variant": "level"
-      },
-      {
-        "text": "Able to destroy enemy stickybombs",
-        "variant": "positive"
-      },
-      {
-        "text": "-0.2 sec faster bomb arm time",
-        "variant": "positive"
-      },
-      {
-        "text": "Max charge time decreased by 70%",
-        "variant": "positive"
-      },
-      {
-        "text": "Up to +35% damage based on charge",
-        "variant": "positive"
-      },
-      {
-        "text": "-15% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "-50% clip size",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Bottle",
-    "link": "/wiki/Bottle",
-    "image": "/w/images/thumb/b/b2/Item_icon_Bottle.png/100px-Item_icon_Bottle.png",
-    "killIcon": "/w/images/6/68/Killicon_bottle.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Demoman"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Normal", "Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "Level 1 Bottle",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Scottish Handshake",
-    "link": "/wiki/Scottish_Handshake",
-    "image": "/w/images/thumb/1/1a/Item_icon_Scottish_Handshake.png/100px-Item_icon_Scottish_Handshake.png",
-    "killIcon": "/w/images/6/6e/Killicon_scottish_handshake.png",
-    "releaseDate": "October 13, 2011 Patch(Manniversary Update & Sale)",
-    "usedBy": ["Demoman"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Bottle",
-        "variant": "level"
-      },
-      {
-        "text": "Your enemies will think you're making peace, right up until the terrifying moment that their hand is very seriously cut! Here's the trick: It's a broken bottle!",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Eyelander",
-    "link": "/wiki/Eyelander",
-    "image": "/w/images/thumb/9/94/Item_icon_Eyelander.png/100px-Item_icon_Eyelander.png",
-    "killIcon": "/w/images/5/53/Killicon_eyelander.png",
-    "releaseDate": "December 17, 2009 Patch(WAR! Update)",
-    "usedBy": ["Demoman"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Sword",
-        "variant": "level"
-      },
-      {
-        "text": " This Weapon has a large melee range and\ndeploys and holsters slower ",
-        "variant": "neutral"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "-25 max health on wearer",
-        "variant": "negative"
-      },
-      {
-        "text": "Gives increased speed and health\nwith every head you take.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Horseless Headless Horsemann's Headtaker",
-    "link": "/wiki/Horseless_Headless_Horsemann%27s_Headtaker",
-    "image": "/w/images/thumb/1/1f/Item_icon_Horseless_Headless_Horsemann%27s_Headtaker.png/100px-Item_icon_Horseless_Headless_Horsemann%27s_Headtaker.png",
-    "killIcon": "/w/images/f/fa/Killicon_horseless_headless_horsemann%27s_headtaker.png",
-    "releaseDate": "October 27, 2010 Patch(Scream Fortress Update)",
-    "usedBy": ["Demoman"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Strange", "Unusual"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Axe",
-        "variant": "level"
-      },
-      {
-        "text": " This Weapon has a large melee range and\ndeploys and holsters slower ",
-        "variant": "neutral"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "-25 max health on wearer",
-        "variant": "negative"
-      },
-      {
-        "text": "Cursed by dark spirits similar to\nthose that dwell within the Eyelander.",
-        "variant": "neutral"
-      },
-      {
-        "text": "( Not Tradable or Marketable )",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Nessie's Nine Iron",
-    "link": "/wiki/Nessie%27s_Nine_Iron",
-    "image": "/w/images/thumb/5/5a/Item_icon_Nessie%27s_Nine_Iron.png/100px-Item_icon_Nessie%27s_Nine_Iron.png",
-    "killIcon": "/w/images/3/34/Killicon_nessie%27s_nine_iron.png",
-    "releaseDate": "July 1, 2011 Patch(Summer Camp Sale)",
-    "usedBy": ["Demoman"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Golf Club",
-        "variant": "level"
-      },
-      {
-        "text": " This Weapon has a large melee range and\ndeploys and holsters slower ",
-        "variant": "neutral"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "-25 max health on wearer",
-        "variant": "negative"
-      },
-      {
-        "text": "Gives increased speed and health\nwith every head you take.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Scotsman's Skullcutter",
-    "link": "/wiki/Scotsman%27s_Skullcutter",
-    "image": "/w/images/thumb/c/c6/Item_icon_Scotsman%27s_Skullcutter.png/100px-Item_icon_Scotsman%27s_Skullcutter.png",
-    "killIcon": "/w/images/2/20/Killicon_scotsman%27s_skullcutter.png",
-    "releaseDate": "May 20, 2010 Patch(Second Community Contribution Update)",
-    "usedBy": ["Demoman"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 5 Axe",
-        "variant": "level"
-      },
-      {
-        "text": " This Weapon has a large melee range and\ndeploys and holsters slower ",
-        "variant": "neutral"
-      },
-      {
-        "text": " When weapon is active: ",
-        "variant": "neutral"
-      },
-      {
-        "text": "+20% damage bonus",
-        "variant": "positive"
-      },
-      {
-        "text": "15% slower move speed on wearer",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Ullapool Caber",
-    "link": "/wiki/Ullapool_Caber",
-    "image": "/w/images/thumb/a/a5/Item_icon_Ullapool_Caber.png/100px-Item_icon_Ullapool_Caber.png",
-    "killIcon": "/w/images/7/74/Killicon_ullapool_caber.png",
-    "releaseDate": "December 17, 2010 Patch(Australian Christmas)",
-    "usedBy": ["Demoman"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Stick Bomb",
-        "variant": "level"
-      },
-      {
-        "text": "20% slower firing speed",
-        "variant": "negative"
-      },
-      {
-        "text": "This weapon deploys 100% slower",
-        "variant": "negative"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "High-yield Scottish face removal.\nA sober person would throw it...\n\nThe first hit will cause an explosion",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Claidheamh M\u00f2r",
-    "link": "/wiki/Claidheamh_M%C3%B2r",
-    "image": "/w/images/thumb/0/0f/Item_icon_Claidheamh_M%C3%B2r.png/100px-Item_icon_Claidheamh_M%C3%B2r.png",
-    "killIcon": "/w/images/9/9e/Killicon_claidheamh_m%C3%B2r.png",
-    "releaseDate": "December 17, 2010 Patch(Australian Christmas)",
-    "usedBy": ["Demoman"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 5 Sword",
-        "variant": "level"
-      },
-      {
-        "text": " When weapon is active: ",
-        "variant": "neutral"
-      },
-      {
-        "text": " This Weapon has a large melee range and\ndeploys and holsters slower ",
-        "variant": "neutral"
-      },
-      {
-        "text": "0.5 sec increase in charge duration",
-        "variant": "positive"
-      },
-      {
-        "text": "Melee kills refill 25% of your charge meter",
-        "variant": "positive"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "15% damage vulnerability on wearer",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Persian Persuader",
-    "link": "/wiki/Persian_Persuader",
-    "image": "/w/images/thumb/9/98/Item_icon_Persian_Persuader.png/100px-Item_icon_Persian_Persuader.png",
-    "killIcon": "/w/images/c/c5/Killicon_persian_persuader.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Demoman"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 10 Sword",
-        "variant": "level"
-      },
-      {
-        "text": " This Weapon has a large melee range and\ndeploys and holsters slower ",
-        "variant": "neutral"
-      },
-      {
-        "text": "Melee hits refill 20% of your charge meter",
-        "variant": "positive"
-      },
-      {
-        "text": "Ammo boxes collected also refill your charge meter",
-        "variant": "positive"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "-80% max primary ammo on wearer",
-        "variant": "negative"
-      },
-      {
-        "text": "-80% max secondary ammo on wearer",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Minigun",
-    "link": "/wiki/Minigun",
-    "image": "/w/images/thumb/a/a7/Item_icon_Minigun.png/100px-Item_icon_Minigun.png",
-    "killIcon": "/w/images/e/ee/Killicon_minigun.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Heavy"],
-    "slot": ["Primary"],
-    "ammoLoaded": "200",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Normal", "Unique", "Strange", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 Minigun",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Iron Curtain",
-    "link": "/wiki/Iron_Curtain",
-    "image": "/w/images/thumb/d/da/Item_icon_Iron_Curtain.png/100px-Item_icon_Iron_Curtain.png",
-    "killIcon": "/w/images/3/3d/Killicon_iron_curtain.png",
-    "releaseDate": "November 19, 2010 Patch",
-    "usedBy": ["Heavy"],
-    "slot": ["Primary"],
-    "ammoLoaded": "200",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique"],
-    "attributes": [
-      {
-        "text": "Level 5 Minigun",
-        "variant": "level"
-      },
-      {
-        "text": "( Achievement Item: Not Tradable or Marketable )",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Natascha",
-    "link": "/wiki/Natascha",
-    "image": "/w/images/thumb/c/cc/Item_icon_Natascha.png/100px-Item_icon_Natascha.png",
-    "killIcon": "/w/images/f/f1/Killicon_natascha.png",
-    "releaseDate": "August 19, 2008 Patch(Heavy Update)",
-    "usedBy": ["Heavy"],
-    "slot": ["Primary"],
-    "ammoLoaded": "200",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Minigun",
-        "variant": "level"
-      },
-      {
-        "text": "On Hit: 100% chance to slow target",
-        "variant": "positive"
-      },
-      {
-        "text": "-20% damage resistance when below 50% health and spun up",
-        "variant": "positive"
-      },
-      {
-        "text": "-25% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "30% slower spin up time",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Brass Beast",
-    "link": "/wiki/Brass_Beast",
-    "image": "/w/images/thumb/6/64/Item_icon_Brass_Beast.png/100px-Item_icon_Brass_Beast.png",
-    "killIcon": "/w/images/0/03/Killicon_brass_beast.png",
-    "releaseDate": "December 17, 2010 Patch(Australian Christmas)",
-    "usedBy": ["Heavy"],
-    "slot": ["Primary"],
-    "ammoLoaded": "200",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 5 Minigun",
-        "variant": "level"
-      },
-      {
-        "text": "+20% damage bonus",
-        "variant": "positive"
-      },
-      {
-        "text": "-20% damage resistance when below 50% health and spun up",
-        "variant": "positive"
-      },
-      {
-        "text": "50% slower spin up time",
-        "variant": "negative"
-      },
-      {
-        "text": "-60% slower move speed while deployed",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Tomislav",
-    "link": "/wiki/Tomislav",
-    "image": "/w/images/thumb/3/3e/Item_icon_Tomislav.png/100px-Item_icon_Tomislav.png",
-    "killIcon": "/w/images/2/27/Killicon_tomislav.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Heavy"],
-    "slot": ["Primary"],
-    "ammoLoaded": "200",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 5 Minigun",
-        "variant": "level"
-      },
-      {
-        "text": "20% faster spin up time",
-        "variant": "positive"
-      },
-      {
-        "text": "20% more accurate",
-        "variant": "positive"
-      },
-      {
-        "text": "Silent Killer: No barrel spin sound",
-        "variant": "positive"
-      },
-      {
-        "text": "20% slower firing speed",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Huo-Long Heater",
-    "link": "/wiki/Huo-Long_Heater",
-    "image": "/w/images/thumb/8/81/Item_icon_Huo-Long_Heater.png/100px-Item_icon_Huo-Long_Heater.png",
-    "killIcon": "/w/images/0/09/Killicon_huo-long_heater.png",
-    "releaseDate": "August 2, 2012 Patch(Triad Pack)",
-    "usedBy": ["Heavy"],
-    "slot": ["Primary"],
-    "ammoLoaded": "200",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Genuine", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Minigun",
-        "variant": "level"
-      },
-      {
-        "text": "Creates a ring of flames while spun up",
-        "variant": "positive"
-      },
-      {
-        "text": "25% damage bonus vs burning players",
-        "variant": "positive"
-      },
-      {
-        "text": "-10% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "Consumes an additional 4 ammo per second while spun up",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Family Business",
-    "link": "/wiki/Family_Business",
-    "image": "/w/images/thumb/c/cd/Item_icon_Family_Business.png/100px-Item_icon_Family_Business.png",
-    "killIcon": "/w/images/3/38/Killicon_family_business.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Heavy"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "8",
-    "ammoCarried": "32",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 10 Shotgun",
-        "variant": "level"
-      },
-      {
-        "text": "+33% clip size",
-        "variant": "positive"
-      },
-      {
-        "text": "+15% faster firing speed",
-        "variant": "positive"
-      },
-      {
-        "text": "-15% damage penalty",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Sandvich",
-    "link": "/wiki/Sandvich",
-    "image": "/w/images/thumb/5/5e/Item_icon_Sandvich.png/100px-Item_icon_Sandvich.png",
-    "killIcon": null,
-    "releaseDate": "August 19, 2008 Patch(Heavy Update)",
-    "usedBy": ["Heavy"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "Recharge (30 seconds)\n  ",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 Lunch Box",
-        "variant": "level"
-      },
-      {
-        "text": "Eat to regain up to 300 health.\nAlt-fire: Share a Sandvich with a friend (Medium Health Kit)",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Robo-Sandvich",
-    "link": "/wiki/Robo-Sandvich",
-    "image": "/w/images/thumb/c/cb/Item_icon_Robo-Sandvich.png/100px-Item_icon_Robo-Sandvich.png",
-    "killIcon": null,
-    "releaseDate": "September 21, 2012 Patch",
-    "usedBy": ["Heavy"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "Recharge (30 seconds)\n  ",
-    "qualities": ["Genuine"],
-    "attributes": [
-      {
-        "text": "Level 1 Lunch Box",
-        "variant": "level"
-      },
-      {
-        "text": "Robots don't just run off oil. They also run off metal things constructed to resemble human food. Why? Why don't you tell me, if you're so smart? If anything, eating a metal sandwich makes MORE sense. Why don't you and oil have a baby that you have shared custody of after you and oil have a messy divorce if you love oil so much?",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Dalokohs Bar",
-    "link": "/wiki/Dalokohs_Bar",
-    "image": "/w/images/thumb/3/35/Item_icon_Dalokohs_Bar.png/100px-Item_icon_Dalokohs_Bar.png",
-    "killIcon": null,
-    "releaseDate": "March 18, 2010 Patch(First Community Contribution Update)",
-    "usedBy": ["Heavy"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "Recharge (10 Seconds)\n  ",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 Lunch Box",
-        "variant": "level"
-      },
-      {
-        "text": "Adds +50 max health for 30 seconds",
-        "variant": "positive"
-      },
-      {
-        "text": "Eat to gain up to 100 health.\nAlt-fire: Share chocolate with a friend (Small Health Kit)",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Fishcake",
-    "link": "/wiki/Fishcake",
-    "image": "/w/images/thumb/9/94/Item_icon_Fishcake.png/100px-Item_icon_Fishcake.png",
-    "killIcon": null,
-    "releaseDate": "April 28, 2011 Patch",
-    "usedBy": ["Heavy"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "Recharge (10 seconds)\n",
-    "qualities": ["Unique"],
-    "attributes": [
-      {
-        "text": "Level 1 Fishcake",
-        "variant": "level"
-      },
-      {
-        "text": "Adds +50 max health for 30 seconds",
-        "variant": "positive"
-      },
-      {
-        "text": "Eat to gain up to 100 health.\nAlt-fire: Share with a friend (Small Health Kit)\n\nVossler Industries All-Natural Artificial-Fish-Derived Food Product",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Buffalo Steak Sandvich",
-    "link": "/wiki/Buffalo_Steak_Sandvich",
-    "image": "/w/images/thumb/6/62/Item_icon_Buffalo_Steak_Sandvich.png/100px-Item_icon_Buffalo_Steak_Sandvich.png",
-    "killIcon": null,
-    "releaseDate": "December 17, 2010 Patch(Australian Christmas)",
-    "usedBy": ["Heavy"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "Recharge (30 Seconds)\n  ",
-    "qualities": ["Unique", "Vintage", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 Lunch Box",
-        "variant": "level"
-      },
-      {
-        "text": "+20% damage vulnerability while active",
-        "variant": "negative"
-      },
-      {
-        "text": "After consuming, move speed is increased, attacks mini-crit, and the player may only use melee weapons. Lasts 16 seconds.\nAlt-fire: Share with a friend (Medium Health Kit)\n\nWho needs bread?",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Fists",
-    "link": "/wiki/Fists",
-    "image": "/w/images/thumb/1/19/Item_icon_Fists.png/100px-Item_icon_Fists.png",
-    "killIcon": "/w/images/2/27/Killicon_fists.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Heavy"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Normal", "Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "Level 1 Fists",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Apoco-Fists",
-    "link": "/wiki/Apoco-Fists",
-    "image": "/w/images/thumb/9/91/Item_icon_Apoco-Fists.png/100px-Item_icon_Apoco-Fists.png",
-    "killIcon": "/w/images/2/23/Killicon_apoco-fists.png",
-    "releaseDate": "November 10, 2011 Patch",
-    "usedBy": ["Heavy"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Genuine", "Strange"],
-    "attributes": [
-      {
-        "text": "Level 10 Fists",
-        "variant": "level"
-      },
-      {
-        "text": "Killing an enemy with a critical hit will dismember your victim. Painfully.",
-        "variant": "positive"
-      },
-      {
-        "text": "Turn every one of your fingers into the Four Horsemen of the Apocalypse! That's over nineteen Horsemen of the Apocalypse per glove! The most Apocalypse we've ever dared attach to one hand!",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Killing Gloves of Boxing",
-    "link": "/wiki/Killing_Gloves_of_Boxing",
-    "image": "/w/images/thumb/f/f6/Item_icon_Killing_Gloves_of_Boxing.png/100px-Item_icon_Killing_Gloves_of_Boxing.png",
-    "killIcon": "/w/images/f/f3/Killicon_killing_gloves_of_boxing.png",
-    "releaseDate": "August 19, 2008 Patch(Heavy Update)",
-    "usedBy": ["Heavy"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 7 Boxing Gloves",
-        "variant": "level"
-      },
-      {
-        "text": "On Kill: 5 seconds of 100% critical chance",
-        "variant": "positive"
-      },
-      {
-        "text": "20% slower firing speed",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Gloves of Running Urgently",
-    "link": "/wiki/Gloves_of_Running_Urgently",
-    "image": "/w/images/thumb/4/4f/Item_icon_Gloves_of_Running_Urgently.png/100px-Item_icon_Gloves_of_Running_Urgently.png",
-    "killIcon": "/w/images/1/13/Killicon_gloves_of_running_urgently.png",
-    "releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
-    "usedBy": ["Heavy"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Boxing Gloves",
-        "variant": "level"
-      },
-      {
-        "text": "+30% faster move speed on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "This weapon holsters 50% slower",
-        "variant": "negative"
-      },
-      {
-        "text": "Maximum health is drained while item is active",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Bread Bite",
-    "link": "/wiki/Bread_Bite",
-    "image": "/w/images/thumb/a/a4/Item_icon_Bread_Bite.png/100px-Item_icon_Bread_Bite.png",
-    "killIcon": "/w/images/4/4f/Killicon_bread_bite.png",
-    "releaseDate": "June 18, 2014 Patch(Love & War Update)",
-    "usedBy": ["Heavy"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "+30% faster move speed on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "This weapon holsters 50% slower",
-        "variant": "negative"
-      },
-      {
-        "text": "Maximum health is drained while item is active",
-        "variant": "negative"
-      },
-      {
-        "text": "Inspired by the TF2 Movie 'Expiration Date'",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Warrior's Spirit",
-    "link": "/wiki/Warrior%27s_Spirit",
-    "image": "/w/images/thumb/8/87/Item_icon_Warrior%27s_Spirit.png/100px-Item_icon_Warrior%27s_Spirit.png",
-    "killIcon": "/w/images/d/d8/Killicon_warrior%27s_spirit.png",
-    "releaseDate": "December 17, 2010 Patch(Australian Christmas)",
-    "usedBy": ["Heavy"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Boxing Gloves",
-        "variant": "level"
-      },
-      {
-        "text": " When weapon is active: ",
-        "variant": "neutral"
-      },
-      {
-        "text": "+30% damage bonus",
-        "variant": "positive"
-      },
-      {
-        "text": "+50 health restored on kill",
-        "variant": "positive"
-      },
-      {
-        "text": "30% damage vulnerability on wearer",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Fists of Steel",
-    "link": "/wiki/Fists_of_Steel",
-    "image": "/w/images/thumb/9/9c/Item_icon_Fists_of_Steel.png/100px-Item_icon_Fists_of_Steel.png",
-    "killIcon": "/w/images/c/ce/Killicon_fists_of_steel.png",
-    "releaseDate": "December 17, 2010 Patch(Australian Christmas)",
-    "usedBy": ["Heavy"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Boxing Gloves",
-        "variant": "level"
-      },
-      {
-        "text": "-40% damage from ranged sources while active",
-        "variant": "positive"
-      },
-      {
-        "text": "+100% damage from melee sources while active",
-        "variant": "negative"
-      },
-      {
-        "text": "This weapon holsters 100% slower",
-        "variant": "negative"
-      },
-      {
-        "text": "-40% maximum overheal on wearer",
-        "variant": "negative"
-      },
-      {
-        "text": "-40% health from healers on wearer",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Eviction Notice",
-    "link": "/wiki/Eviction_Notice",
-    "image": "/w/images/thumb/6/62/Item_icon_Eviction_Notice.png/100px-Item_icon_Eviction_Notice.png",
-    "killIcon": "/w/images/4/44/Killicon_eviction_notice.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Heavy"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Boxing Gloves",
-        "variant": "level"
-      },
-      {
-        "text": "+40% faster firing speed",
-        "variant": "positive"
-      },
-      {
-        "text": "On Hit: Gain a speed boost",
-        "variant": "positive"
-      },
-      {
-        "text": "+15% faster move speed on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "-60% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "Maximum health is drained while item is active",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Holiday Punch",
-    "link": "/wiki/Holiday_Punch",
-    "image": "/w/images/thumb/5/54/Item_icon_Holiday_Punch.png/100px-Item_icon_Holiday_Punch.png",
-    "killIcon": "/w/images/1/11/Killicon_holiday_punch.png",
-    "releaseDate": "December 15, 2011 Patch(Australian Christmas 2011)",
-    "usedBy": ["Heavy"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Fists",
-        "variant": "level"
-      },
-      {
-        "text": "Critical hit forces victim to laugh",
-        "variant": "positive"
-      },
-      {
-        "text": "Always critical hit from behind",
-        "variant": "positive"
-      },
-      {
-        "text": "On Hit: Force enemies to laugh who are also wearing this item",
-        "variant": "positive"
-      },
-      {
-        "text": "Critical hits do no damage",
-        "variant": "negative"
-      },
-      {
-        "text": "Be the life of the war party with these laugh-inducing punch-mittens.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Frontier Justice",
-    "link": "/wiki/Frontier_Justice",
-    "image": "/w/images/thumb/2/26/Item_icon_Frontier_Justice.png/100px-Item_icon_Frontier_Justice.png",
-    "killIcon": "/w/images/c/c8/Killicon_frontier_justice.png",
-    "releaseDate": "July 8, 2010 Patch(Engineer Update)",
-    "usedBy": ["Engineer"],
-    "slot": ["Primary"],
-    "ammoLoaded": "3",
-    "ammoCarried": "32",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Shotgun",
-        "variant": "level"
-      },
-      {
-        "text": "Gain 2 revenge crits for each sentry kill and\n1 for each sentry assist when your sentry is destroyed",
-        "variant": "positive"
-      },
-      {
-        "text": "-50% clip size",
-        "variant": "negative"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "Revenge crits are lost on death",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Widowmaker",
-    "link": "/wiki/Widowmaker",
-    "image": "/w/images/thumb/b/b8/Item_icon_Widowmaker.png/100px-Item_icon_Widowmaker.png",
-    "killIcon": "/w/images/0/0a/Killicon_widowmaker.png",
-    "releaseDate": "August 18, 2011 Patch(Manno-Technology Bundle)",
-    "usedBy": ["Engineer"],
-    "slot": ["Primary"],
-    "ammoLoaded": "1 per 30 Metal",
-    "ammoCarried": "200 Metal (allows 6 shots)",
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Genuine", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Shotgun",
-        "variant": "level"
-      },
-      {
-        "text": "On Hit: damage dealt is returned as ammo",
-        "variant": "positive"
-      },
-      {
-        "text": "No reload necessary",
-        "variant": "positive"
-      },
-      {
-        "text": "10% increased damage to your sentry's target",
-        "variant": "positive"
-      },
-      {
-        "text": "Per Shot: -30 ammo",
-        "variant": "negative"
-      },
-      {
-        "text": "Uses metal for ammo",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Pomson 6000",
-    "link": "/wiki/Pomson_6000",
-    "image": "/w/images/thumb/8/89/Item_icon_Pomson_6000.png/100px-Item_icon_Pomson_6000.png",
-    "killIcon": "/w/images/b/b5/Killicon_pomson_6000.png",
-    "releaseDate": "December 15, 2011 Patch(Australian Christmas 2011)",
-    "usedBy": ["Engineer"],
-    "slot": ["Primary"],
-    "ammoLoaded": "4",
-    "ammoCarried": "Unlimited",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Indivisible Particle Smasher",
-        "variant": "level"
-      },
-      {
-        "text": "Does not require ammo",
-        "variant": "positive"
-      },
-      {
-        "text": "Projectile cannot be deflected",
-        "variant": "positive"
-      },
-      {
-        "text": "On Hit: Victim loses up to 10% Medigun charge",
-        "variant": "positive"
-      },
-      {
-        "text": "On Hit: Victim loses up to 20% cloak",
-        "variant": "positive"
-      },
-      {
-        "text": "Deals only 20% damage to buildings",
-        "variant": "negative"
-      },
-      {
-        "text": "Being an innovative hand-held irradiating utensil capable of producing rapid pulses of high-amplitude radiation in sufficient quantity as to immolate, maim and otherwise incapacitate the Irish.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Rescue Ranger",
-    "link": "/wiki/Rescue_Ranger",
-    "image": "/w/images/thumb/2/29/Item_icon_Rescue_Ranger.png/100px-Item_icon_Rescue_Ranger.png",
-    "killIcon": "/w/images/1/14/Killicon_rescue_ranger.png",
-    "releaseDate": "December 20, 2012 Patch(Mecha Update)",
-    "usedBy": ["Engineer"],
-    "slot": ["Primary"],
-    "ammoLoaded": "4",
-    "ammoCarried": "16",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Shotgun",
-        "variant": "level"
-      },
-      {
-        "text": "Alt-Fire: Use 100 metal to pick up your targeted building from long range",
-        "variant": "positive"
-      },
-      {
-        "text": "Fires a special bolt that can repair friendly buildings",
-        "variant": "positive"
-      },
-      {
-        "text": "-34% clip size",
-        "variant": "negative"
-      },
-      {
-        "text": "-50% max primary ammo on wearer",
-        "variant": "negative"
-      },
-      {
-        "text": "Self mark for death when hauling buildings",
-        "variant": "negative"
-      },
-      {
-        "text": "4-to-1 health-to-metal ratio when repairing buildings",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Wrangler",
-    "link": "/wiki/Wrangler",
-    "image": "/w/images/thumb/c/ce/Item_icon_Wrangler.png/100px-Item_icon_Wrangler.png",
-    "killIcon": "/w/images/e/e0/Killicon_wrangler.png",
-    "releaseDate": "July 8, 2010 Patch(Engineer Update)",
-    "usedBy": ["Engineer"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Laser Pointer",
-        "variant": "level"
-      },
-      {
-        "text": "Take manual control of your Sentry Gun.\nWrangled sentries gain a shield that reduces\ndamage and repairs by 66%.\nSentries are disabled for 3 seconds after becoming unwrangled.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Giger Counter",
-    "link": "/wiki/Giger_Counter",
-    "image": "/w/images/thumb/5/5d/Item_icon_Giger_Counter.png/100px-Item_icon_Giger_Counter.png",
-    "killIcon": "/w/images/0/03/Killicon_giger_counter.png",
-    "releaseDate": "October 6, 2015 Patch(Invasion Community Update)",
-    "usedBy": ["Engineer"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "\nLaser Pointer",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Short Circuit",
-    "link": "/wiki/Short_Circuit",
-    "image": "/w/images/thumb/3/36/Item_icon_Short_Circuit.png/100px-Item_icon_Short_Circuit.png",
-    "killIcon": "/w/images/1/10/Killicon_short_circuit.png",
-    "releaseDate": "August 18, 2011 Patch(Manno-Technology Bundle)",
-    "usedBy": ["Engineer"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "1 per 5 Metal",
-    "ammoCarried": "200 Metal (allows 40 uses)",
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Genuine", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Robot Arm",
-        "variant": "level"
-      },
-      {
-        "text": "Alt-Fire: Launches a projectile-consuming energy ball.  Costs 65 metal.",
-        "variant": "positive"
-      },
-      {
-        "text": "No reload necessary",
-        "variant": "positive"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "Per Shot: -5 ammo",
-        "variant": "negative"
-      },
-      {
-        "text": "Uses metal for ammo",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Wrench",
-    "link": "/wiki/Wrench",
-    "image": "/w/images/thumb/7/7d/Item_icon_Wrench.png/100px-Item_icon_Wrench.png",
-    "killIcon": "/w/images/7/7a/Killicon_wrench.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Engineer"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Normal", "Unique", "Strange", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 Wrench",
-        "variant": "level"
-      },
-      {
-        "text": "Upgrades, repairs and speeds up construction of friendly buildings on hit",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Golden Wrench",
-    "link": "/wiki/Golden_Wrench",
-    "image": "/w/images/thumb/9/95/Item_icon_Golden_Wrench.png/100px-Item_icon_Golden_Wrench.png",
-    "killIcon": "/w/images/0/0e/Killicon_golden_wrench.png",
-    "releaseDate": "July 1, 2010 Patch",
-    "usedBy": ["Engineer"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique"],
-    "attributes": [
-      {
-        "text": "Imbued with an ancient power",
-        "variant": "positive"
-      },
-      {
-        "text": "Wrench no. [#]",
-        "variant": "neutral"
-      },
-      {
-        "text": "( Not Tradable or Marketable )",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Gunslinger",
-    "link": "/wiki/Gunslinger",
-    "image": "/w/images/thumb/c/ca/Item_icon_Gunslinger.png/100px-Item_icon_Gunslinger.png",
-    "killIcon": "/w/images/b/b2/Killicon_gunslinger.png",
-    "releaseDate": "July 8, 2010 Patch(Engineer Update)",
-    "usedBy": ["Engineer"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 15 Robot Arm",
-        "variant": "level"
-      },
-      {
-        "text": "+25 max health on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "Sentry build speed increased by 150%",
-        "variant": "positive"
-      },
-      {
-        "text": "Third successful punch in a row always crits",
-        "variant": "positive"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "Replaces the Sentry with a Mini-Sentry",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Southern Hospitality",
-    "link": "/wiki/Southern_Hospitality",
-    "image": "/w/images/thumb/e/ec/Item_icon_Southern_Hospitality.png/100px-Item_icon_Southern_Hospitality.png",
-    "killIcon": "/w/images/1/1d/Killicon_southern_hospitality.png",
-    "releaseDate": "July 8, 2010 Patch(Engineer Update)",
-    "usedBy": ["Engineer"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 20 Wrench",
-        "variant": "level"
-      },
-      {
-        "text": "On Hit: Bleed for 5 seconds",
-        "variant": "positive"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "20% fire damage vulnerability on wearer",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Jag",
-    "link": "/wiki/Jag",
-    "image": "/w/images/thumb/4/49/Item_icon_Jag.png/100px-Item_icon_Jag.png",
-    "killIcon": "/w/images/0/0c/Killicon_jag.png",
-    "releaseDate": "December 17, 2010 Patch(Australian Christmas)",
-    "usedBy": ["Engineer"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 15 Wrench",
-        "variant": "level"
-      },
-      {
-        "text": "Construction hit speed boost increased by 30%",
-        "variant": "positive"
-      },
-      {
-        "text": "+15% faster firing speed",
-        "variant": "positive"
-      },
-      {
-        "text": "-25% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "20% slower repair rate",
-        "variant": "negative"
-      },
-      {
-        "text": "-33% damage penalty vs buildings",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Eureka Effect",
-    "link": "/wiki/Eureka_Effect",
-    "image": "/w/images/thumb/c/cf/Item_icon_Eureka_Effect.png/100px-Item_icon_Eureka_Effect.png",
-    "killIcon": "/w/images/2/2c/Killicon_eureka_effect.png",
-    "releaseDate": "December 15, 2011 Patch(Australian Christmas 2011)",
-    "usedBy": ["Engineer"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 20 Wrench",
-        "variant": "level"
-      },
-      {
-        "text": "Press your reload key to choose to teleport to spawn or your exit teleporter",
-        "variant": "positive"
-      },
-      {
-        "text": "-50% metal cost when constructing or upgrading teleporters",
-        "variant": "positive"
-      },
-      {
-        "text": "Construction hit speed boost decreased by 50%",
-        "variant": "negative"
-      },
-      {
-        "text": "20% less metal from pickups and dispensers",
-        "variant": "negative"
-      },
-      {
-        "text": "Being a tool that eliminates exertion by harnessing the electrical discharges of thunder-storms for the vigorous coercion of bolts, nuts, pipes and similar into their rightful places. May also be used to bludgeon.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Destruction PDA",
-    "link": "/wiki/PDA",
-    "image": "/w/images/thumb/2/26/Item_icon_PDA_Destroy.png/100px-Item_icon_PDA_Destroy.png",
-    "killIcon": null,
-    "releaseDate": "unknown",
-    "usedBy": ["Engineer"],
-    "slot": ["PDA 1", "PDA 2"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Normal", "Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "Level 1 PDA",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Syringe Gun",
-    "link": "/wiki/Syringe_Gun",
-    "image": "/w/images/thumb/c/c4/Item_icon_Syringe_Gun.png/100px-Item_icon_Syringe_Gun.png",
-    "killIcon": "/w/images/8/8b/Killicon_syringe_gun.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Medic"],
-    "slot": ["Primary"],
-    "ammoLoaded": "40",
-    "ammoCarried": "150",
-    "reloadType": "Clip\n  ",
-    "qualities": ["Normal", "Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "Level 1 Syringe Gun",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Blutsauger",
-    "link": "/wiki/Blutsauger",
-    "image": "/w/images/thumb/1/13/Item_icon_Blutsauger.png/100px-Item_icon_Blutsauger.png",
-    "killIcon": "/w/images/b/b6/Killicon_blutsauger.png",
-    "releaseDate": "April 29, 2008 Patch(Gold Rush Update)",
-    "usedBy": ["Medic"],
-    "slot": ["Primary"],
-    "ammoLoaded": "40",
-    "ammoCarried": "150",
-    "reloadType": "Clip\n  ",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Syringe Gun",
-        "variant": "level"
-      },
-      {
-        "text": "On Hit: Gain up to +3 health",
-        "variant": "positive"
-      },
-      {
-        "text": "-2 health regenerated per second on wearer",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Crusader's Crossbow",
-    "link": "/wiki/Crusader%27s_Crossbow",
-    "image": "/w/images/thumb/9/9c/Item_icon_Crusader%27s_Crossbow.png/100px-Item_icon_Crusader%27s_Crossbow.png",
-    "killIcon": "/w/images/9/95/Killicon_crusader%27s_crossbow.png",
-    "releaseDate": "December 17, 2010 Patch(Australian Christmas)",
-    "usedBy": ["Medic"],
-    "slot": ["Primary"],
-    "ammoLoaded": "1",
-    "ammoCarried": "38",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 15 Crossbow",
-        "variant": "level"
-      },
-      {
-        "text": "No headshots",
-        "variant": "negative"
-      },
-      {
-        "text": "-75% max primary ammo on wearer",
-        "variant": "negative"
-      },
-      {
-        "text": "Fires special bolts that heal teammates and deals damage\nbased on distance traveled\nThis weapon will reload automatically when not active",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Overdose",
-    "link": "/wiki/Overdose",
-    "image": "/w/images/thumb/f/fe/Item_icon_Overdose.png/100px-Item_icon_Overdose.png",
-    "killIcon": "/w/images/8/8d/Killicon_overdose.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Medic"],
-    "slot": ["Primary"],
-    "ammoLoaded": "40",
-    "ammoCarried": "150",
-    "reloadType": "Clip\n  ",
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Syringe Gun Prototype",
-        "variant": "level"
-      },
-      {
-        "text": "-15% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "While active, movement speed increases based on \u00dcberCharge percentage to a maximum of +20%",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Medi Gun",
-    "link": "/wiki/Medi_Gun",
-    "image": "/w/images/thumb/4/4a/Item_icon_Medi_Gun.png/100px-Item_icon_Medi_Gun.png",
-    "killIcon": null,
-    "releaseDate": "unknown",
-    "usedBy": ["Medic"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Normal", "Unique", "Strange", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 Medi Gun",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Kritzkrieg",
-    "link": "/wiki/Kritzkrieg",
-    "image": "/w/images/thumb/8/85/Item_icon_Kritzkrieg.png/100px-Item_icon_Kritzkrieg.png",
-    "killIcon": null,
-    "releaseDate": "April 29, 2008 Patch(Gold Rush Update)",
-    "usedBy": ["Medic"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 8 Medi Gun",
-        "variant": "level"
-      },
-      {
-        "text": " \u00dcberCharge grants 100% critical chance ",
-        "variant": "neutral"
-      },
-      {
-        "text": "+25% \u00dcberCharge rate",
-        "variant": "positive"
-      }
-    ]
-  },
-  {
-    "name": "Quick-Fix",
-    "link": "/wiki/Quick-Fix",
-    "image": "/w/images/thumb/5/50/Item_icon_Quick-Fix.png/100px-Item_icon_Quick-Fix.png",
-    "killIcon": null,
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Medic"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 8 Medi Gun Prototype",
-        "variant": "level"
-      },
-      {
-        "text": " \u00dcberCharge increases healing to 300% and grants immunity to movement-impairing effects ",
-        "variant": "neutral"
-      },
-      {
-        "text": "+40% heal rate",
-        "variant": "positive"
-      },
-      {
-        "text": "+10% \u00dcberCharge rate",
-        "variant": "positive"
-      },
-      {
-        "text": "50% max overheal",
-        "variant": "negative"
-      },
-      {
-        "text": "Mirror the blast jumps and shield charges of patients.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Vaccinator",
-    "link": "/wiki/Vaccinator",
-    "image": "/w/images/thumb/9/9d/Item_icon_Vaccinator.png/100px-Item_icon_Vaccinator.png",
-    "killIcon": null,
-    "releaseDate": "December 20, 2012 Patch(Mecha Update)",
-    "usedBy": ["Medic"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 8 Vaccinator",
-        "variant": "level"
-      },
-      {
-        "text": "+67% \u00dcberCharge rate",
-        "variant": "positive"
-      },
-      {
-        "text": "Press your reload key to cycle through resist types.\nWhile healing, provides you and your target with a constant 10% resistance to the selected damage type.",
-        "variant": "positive"
-      },
-      {
-        "text": "-33% \u00dcberCharge rate on Overhealed patients",
-        "variant": "negative"
-      },
-      {
-        "text": "-66% Overheal build rate",
-        "variant": "negative"
-      },
-      {
-        "text": "\u00dcberCharge provides a 2.5 second resistance bubble that blocks 75% base damage and 100% crit damage of the selected type to the Medic and Patient.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Bonesaw",
-    "link": "/wiki/Bonesaw",
-    "image": "/w/images/thumb/8/8d/Item_icon_Bonesaw.png/100px-Item_icon_Bonesaw.png",
-    "killIcon": "/w/images/0/08/Killicon_bonesaw.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Medic"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Normal", "Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "Level 1 Bonesaw",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Ubersaw",
-    "link": "/wiki/Ubersaw",
-    "image": "/w/images/thumb/0/04/Item_icon_Ubersaw.png/100px-Item_icon_Ubersaw.png",
-    "killIcon": "/w/images/9/9a/Killicon_ubersaw.png",
-    "releaseDate": "April 29, 2008 Patch(Gold Rush Update)",
-    "usedBy": ["Medic"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 10 Bonesaw",
-        "variant": "level"
-      },
-      {
-        "text": "On Hit: 25% \u00dcberCharge added",
-        "variant": "positive"
-      },
-      {
-        "text": "20% slower firing speed",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Vita-Saw",
-    "link": "/wiki/Vita-Saw",
-    "image": "/w/images/thumb/7/70/Item_icon_Vita-Saw.png/100px-Item_icon_Vita-Saw.png",
-    "killIcon": "/w/images/c/c3/Killicon_vita-saw.png",
-    "releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
-    "usedBy": ["Medic"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Bonesaw",
-        "variant": "level"
-      },
-      {
-        "text": "Collect the organs of people you hit",
-        "variant": "positive"
-      },
-      {
-        "text": "-10 max health on wearer",
-        "variant": "negative"
-      },
-      {
-        "text": "A percentage of your \u00dcberCharge level is retained on death, based on the number of organs harvested (15% per). Total \u00dcberCharge retained on spawn caps at 60%.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Amputator",
-    "link": "/wiki/Amputator",
-    "image": "/w/images/thumb/a/ab/Item_icon_Amputator.png/100px-Item_icon_Amputator.png",
-    "killIcon": "/w/images/3/35/Killicon_amputator.png",
-    "releaseDate": "December 17, 2010 Patch(Australian Christmas)",
-    "usedBy": ["Medic"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 15 Bonesaw",
-        "variant": "level"
-      },
-      {
-        "text": " When weapon is active: ",
-        "variant": "neutral"
-      },
-      {
-        "text": "+3 health regenerated per second on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "Alt-Fire: Applies a healing effect to all nearby teammates",
-        "variant": "positive"
-      },
-      {
-        "text": "-20% damage penalty",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Solemn Vow",
-    "link": "/wiki/Solemn_Vow",
-    "image": "/w/images/thumb/d/db/Item_icon_Solemn_Vow.png/100px-Item_icon_Solemn_Vow.png",
-    "killIcon": "/w/images/9/98/Killicon_solemn_vow.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Medic"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Bust of Hippocrates",
-        "variant": "level"
-      },
-      {
-        "text": "Allows you to see enemy health",
-        "variant": "positive"
-      },
-      {
-        "text": "10% slower firing speed",
-        "variant": "negative"
-      },
-      {
-        "text": "'Do no harm.'",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Sniper Rifle",
-    "link": "/wiki/Sniper_Rifle",
-    "image": "/w/images/thumb/a/a1/Item_icon_Sniper_Rifle.png/100px-Item_icon_Sniper_Rifle.png",
-    "killIcon": "/w/images/f/fe/Killicon_sniper_rifle.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Sniper"],
-    "slot": ["Primary"],
-    "ammoLoaded": "25",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Normal", "Unique", "Strange", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 Sniper Rifle",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "AWPer Hand",
-    "link": "/wiki/AWPer_Hand",
-    "image": "/w/images/thumb/2/24/Item_icon_AWPer_Hand.png/100px-Item_icon_AWPer_Hand.png",
-    "killIcon": "/w/images/f/fe/Killicon_sniper_rifle.png",
-    "releaseDate": "August 15, 2012 Patch",
-    "usedBy": ["Sniper"],
-    "slot": ["Primary"],
-    "ammoLoaded": "25",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Genuine", "Strange"],
-    "attributes": [
-      {
-        "text": "Level 1 Sniper Rifle",
-        "variant": "level"
-      },
-      {
-        "text": "This controversial bolt-action beaut is banned in thousands of countries, and with good reason: You could really hurt someone with this thing.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Huntsman",
-    "link": "/wiki/Huntsman",
-    "image": "/w/images/thumb/f/f8/Item_icon_Huntsman.png/100px-Item_icon_Huntsman.png",
-    "killIcon": "/w/images/a/ad/Killicon_huntsman.png",
-    "releaseDate": "May 21, 2009 Patch(Sniper vs. Spy Update)",
-    "usedBy": ["Sniper"],
-    "slot": ["Primary"],
-    "ammoLoaded": "1",
-    "ammoCarried": "12",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Bow",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Fortified Compound",
-    "link": "/wiki/Fortified_Compound",
-    "image": "/w/images/thumb/8/89/Item_icon_Fortified_Compound.png/100px-Item_icon_Fortified_Compound.png",
-    "killIcon": "/w/images/a/ad/Killicon_huntsman.png",
-    "releaseDate": "February 11, 2014 Patch",
-    "usedBy": ["Sniper"],
-    "slot": ["Primary"],
-    "ammoLoaded": "1",
-    "ammoCarried": "12",
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Genuine", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Bow",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Sydney Sleeper",
-    "link": "/wiki/Sydney_Sleeper",
-    "image": "/w/images/thumb/6/6a/Item_icon_Sydney_Sleeper.png/100px-Item_icon_Sydney_Sleeper.png",
-    "killIcon": "/w/images/3/3b/Killicon_sydney_sleeper.png",
-    "releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
-    "usedBy": ["Sniper"],
-    "slot": ["Primary"],
-    "ammoLoaded": "25",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 Sniper Rifle",
-        "variant": "level"
-      },
-      {
-        "text": "+25% charge rate",
-        "variant": "positive"
-      },
-      {
-        "text": "On Scoped Hit: Apply Jarate for 2 to 5 seconds based on charge level.\nNature's Call: Scoped headshots always mini-crit and reduce the remaining cooldown of Jarate by 1 second.",
-        "variant": "positive"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "No headshots",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Bazaar Bargain",
-    "link": "/wiki/Bazaar_Bargain",
-    "image": "/w/images/thumb/f/f4/Item_icon_Bazaar_Bargain.png/100px-Item_icon_Bazaar_Bargain.png",
-    "killIcon": "/w/images/6/60/Killicon_bazaar_bargain.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Sniper"],
-    "slot": ["Primary"],
-    "ammoLoaded": "25",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 10 Sniper Rifle",
-        "variant": "level"
-      },
-      {
-        "text": "Base charge rate decreased by 50%",
-        "variant": "negative"
-      },
-      {
-        "text": "Each scoped headshot kill increases the weapon's charge rate by 25% up to 200%.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Machina",
-    "link": "/wiki/Machina",
-    "image": "/w/images/thumb/a/ae/Item_icon_Machina.png/100px-Item_icon_Machina.png",
-    "killIcon": "/w/images/0/09/Killicon_machina.png",
-    "releaseDate": "August 18, 2011 Patch(Manno-Technology Bundle)",
-    "usedBy": ["Sniper"],
-    "slot": ["Primary"],
-    "ammoLoaded": "25",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Genuine", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Sniper Rifle",
-        "variant": "level"
-      },
-      {
-        "text": "On Full Charge: +15% damage per shot",
-        "variant": "positive"
-      },
-      {
-        "text": "On Full Charge: Projectiles penetrate players",
-        "variant": "positive"
-      },
-      {
-        "text": "Cannot fire unless zoomed",
-        "variant": "negative"
-      },
-      {
-        "text": "Fires tracer rounds",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Shooting Star",
-    "link": "/wiki/Shooting_Star",
-    "image": "/w/images/thumb/d/d7/Item_icon_Shooting_Star.png/100px-Item_icon_Shooting_Star.png",
-    "killIcon": "/w/images/5/51/Killicon_shooting_star.png",
-    "releaseDate": "October 6, 2015 Patch(Invasion Community Update)",
-    "usedBy": ["Sniper"],
-    "slot": ["Primary"],
-    "ammoLoaded": "25",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "\nSniper Rifle",
-        "variant": "level"
-      },
-      {
-        "text": "On Full Charge: +15% damage per shot",
-        "variant": "positive"
-      },
-      {
-        "text": "On Full Charge: Projectiles penetrate players",
-        "variant": "positive"
-      },
-      {
-        "text": "Cannot fire unless zoomed",
-        "variant": "negative"
-      },
-      {
-        "text": "Fires tracer rounds",
-        "variant": "negative"
-      },
-      {
-        "text": "Turn your enemies in to ash!",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Hitman's Heatmaker",
-    "link": "/wiki/Hitman%27s_Heatmaker",
-    "image": "/w/images/thumb/1/18/Item_icon_Hitman%27s_Heatmaker.png/100px-Item_icon_Hitman%27s_Heatmaker.png",
-    "killIcon": "/w/images/1/17/Killicon_hitman%27s_heatmaker.png",
-    "releaseDate": "June 27, 2012 Patch(Pyromania Update)",
-    "usedBy": ["Sniper"],
-    "slot": ["Primary"],
-    "ammoLoaded": "25",
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 Sniper Rifle",
-        "variant": "level"
-      },
-      {
-        "text": "Gain Focus on kills and assists",
-        "variant": "positive"
-      },
-      {
-        "text": "Press 'Reload' to activate focus\nIn Focus: +25% faster charge and no unscoping",
-        "variant": "positive"
-      },
-      {
-        "text": "-20% damage on body shot",
-        "variant": "negative"
-      },
-      {
-        "text": "Heads will roll.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Classic",
-    "link": "/wiki/Classic",
-    "image": "/w/images/thumb/7/73/Item_icon_Classic.png/100px-Item_icon_Classic.png",
-    "killIcon": "/w/images/4/40/Killicon_classic.png",
-    "releaseDate": "June 18, 2014 Patch(Love & War Update)",
-    "usedBy": ["Sniper"],
-    "slot": ["Primary"],
-    "ammoLoaded": "25",
-    "ammoCarried": null,
-    "reloadType": "Single\n  ",
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Sniper Rifle",
-        "variant": "level"
-      },
-      {
-        "text": "Charge and fire shots independent of zoom",
-        "variant": "positive"
-      },
-      {
-        "text": "No headshots when not fully charged",
-        "variant": "negative"
-      },
-      {
-        "text": "-10% damage on body shot",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "SMG",
-    "link": "/wiki/SMG",
-    "image": "/w/images/thumb/5/50/Item_icon_SMG.png/100px-Item_icon_SMG.png",
-    "killIcon": "/w/images/5/51/Killicon_SMG.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Sniper"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "25",
-    "ammoCarried": "75",
-    "reloadType": "Clip\n  ",
-    "qualities": ["Normal", "Unique", "Strange", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 SMG",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Cleaner's Carbine",
-    "link": "/wiki/Cleaner%27s_Carbine",
-    "image": "/w/images/thumb/6/64/Item_icon_Cleaner%27s_Carbine.png/100px-Item_icon_Cleaner%27s_Carbine.png",
-    "killIcon": "/w/images/8/81/Killicon_cleaner%27s_carbine.png",
-    "releaseDate": "June 27, 2012 Patch(Pyromania Update)",
-    "usedBy": ["Sniper"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "20",
-    "ammoCarried": "75",
-    "reloadType": "Clip\n  ",
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 SMG",
-        "variant": "level"
-      },
-      {
-        "text": "Secondary fire when charged grants mini-crits for 8 seconds",
-        "variant": "positive"
-      },
-      {
-        "text": "Dealing damage fills charge meter",
-        "variant": "positive"
-      },
-      {
-        "text": "-20% clip size",
-        "variant": "negative"
-      },
-      {
-        "text": "25% slower firing speed",
-        "variant": "negative"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Jarate",
-    "link": "/wiki/Jarate",
-    "image": "/w/images/thumb/b/b3/Item_icon_Jarate.png/100px-Item_icon_Jarate.png",
-    "killIcon": null,
-    "releaseDate": "May 21, 2009 Patch(Sniper vs. Spy Update)",
-    "usedBy": ["Sniper"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "Recharge (20 Seconds)\n  ",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Jar Based Karate",
-        "variant": "level"
-      },
-      {
-        "text": " Coated enemies take mini-crits\nCan be used to extinguish fires ",
-        "variant": "neutral"
-      },
-      {
-        "text": "Extinguishing teammates reduces cooldown by -20%",
-        "variant": "positive"
-      }
-    ]
-  },
-  {
-    "name": "Self-Aware Beauty Mark",
-    "link": "/wiki/Self-Aware_Beauty_Mark",
-    "image": "/w/images/thumb/2/2e/Item_icon_Self-Aware_Beauty_Mark.png/100px-Item_icon_Self-Aware_Beauty_Mark.png",
-    "killIcon": null,
-    "releaseDate": "June 18, 2014 Patch(Love & War Update)",
-    "usedBy": ["Sniper"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "Recharge (20 seconds)\n  ",
-    "qualities": ["Unique", "Strange"],
-    "attributes": [
-      {
-        "text": " Coated enemies take mini-crits\nCan be used to extinguish fires ",
-        "variant": "neutral"
-      },
-      {
-        "text": "Extinguishing teammates reduces cooldown by -20%",
-        "variant": "positive"
-      },
-      {
-        "text": "Inspired by the TF2 Movie 'Expiration Date'",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Razorback",
-    "link": "/wiki/Razorback",
-    "image": "/w/images/thumb/0/0f/Item_icon_Razorback.png/100px-Item_icon_Razorback.png",
-    "killIcon": null,
-    "releaseDate": "May 21, 2009 Patch(Sniper vs. Spy Update)",
-    "usedBy": ["Sniper"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "Recharge (30 Seconds)\n  ",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Shield",
-        "variant": "level"
-      },
-      {
-        "text": "Blocks a single backstab attempt",
-        "variant": "positive"
-      },
-      {
-        "text": "-100% maximum overheal on wearer",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Darwin's Danger Shield",
-    "link": "/wiki/Darwin%27s_Danger_Shield",
-    "image": "/w/images/thumb/4/44/Item_icon_Darwin%27s_Danger_Shield.png/100px-Item_icon_Darwin%27s_Danger_Shield.png",
-    "killIcon": null,
-    "releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
-    "usedBy": ["Sniper"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Shield",
-        "variant": "level"
-      },
-      {
-        "text": "+50% fire damage resistance on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "Immune to the effects of afterburn",
-        "variant": "positive"
-      }
-    ]
-  },
-  {
-    "name": "Cozy Camper",
-    "link": "/wiki/Cozy_Camper",
-    "image": "/w/images/thumb/0/01/Item_icon_Cozy_Camper.png/100px-Item_icon_Cozy_Camper.png",
-    "killIcon": null,
-    "releaseDate": "March 15, 2012 Patch",
-    "usedBy": ["Sniper"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 10 Backpack",
-        "variant": "level"
-      },
-      {
-        "text": "+4 health regenerated per second on wearer",
-        "variant": "positive"
-      },
-      {
-        "text": "No flinching when aiming and fully charged",
-        "variant": "positive"
-      },
-      {
-        "text": "Knockback reduced by 20% when aiming",
-        "variant": "positive"
-      }
-    ]
-  },
-  {
-    "name": "Kukri",
-    "link": "/wiki/Kukri",
-    "image": "/w/images/thumb/e/ea/Item_icon_Kukri.png/100px-Item_icon_Kukri.png",
-    "killIcon": "/w/images/9/9d/Killicon_kukri.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Sniper"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Normal", "Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "Level 1 Kukri",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Tribalman's Shiv",
-    "link": "/wiki/Tribalman%27s_Shiv",
-    "image": "/w/images/thumb/5/55/Item_icon_Tribalman%27s_Shiv.png/100px-Item_icon_Tribalman%27s_Shiv.png",
-    "killIcon": "/w/images/c/ce/Killicon_tribalman%27s_shiv.png",
-    "releaseDate": "May 20, 2010 Patch(Second Community Contribution Update)",
-    "usedBy": ["Sniper"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Kukri",
-        "variant": "level"
-      },
-      {
-        "text": "On Hit: Bleed for 6 seconds",
-        "variant": "positive"
-      },
-      {
-        "text": "-50% damage penalty",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Bushwacka",
-    "link": "/wiki/Bushwacka",
-    "image": "/w/images/thumb/4/46/Item_icon_Bushwacka.png/100px-Item_icon_Bushwacka.png",
-    "killIcon": "/w/images/4/42/Killicon_bushwacka.png",
-    "releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
-    "usedBy": ["Sniper"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Kukri",
-        "variant": "level"
-      },
-      {
-        "text": " When weapon is active: ",
-        "variant": "neutral"
-      },
-      {
-        "text": "Crits whenever it would normally mini-crit",
-        "variant": "positive"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "20% damage vulnerability on wearer",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Shahanshah",
-    "link": "/wiki/Shahanshah",
-    "image": "/w/images/thumb/8/8d/Item_icon_Shahanshah.png/100px-Item_icon_Shahanshah.png",
-    "killIcon": "/w/images/6/6e/Killicon_shahanshah.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Sniper"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 5 Kukri",
-        "variant": "level"
-      },
-      {
-        "text": "+25% increase in damage when health <50% of max",
-        "variant": "positive"
-      },
-      {
-        "text": "-25% decrease in damage when health >50% of max",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Revolver",
-    "link": "/wiki/Revolver",
-    "image": "/w/images/thumb/1/1f/Item_icon_Revolver.png/100px-Item_icon_Revolver.png",
-    "killIcon": "/w/images/3/34/Killicon_revolver.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Spy"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "6",
-    "ammoCarried": "24",
-    "reloadType": "Clip\n  ",
-    "qualities": ["Normal", "Unique", "Strange", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 Revolver",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Big Kill",
-    "link": "/wiki/Big_Kill",
-    "image": "/w/images/thumb/3/31/Item_icon_Big_Kill.png/100px-Item_icon_Big_Kill.png",
-    "killIcon": "/w/images/e/e8/Killicon_big_kill.png",
-    "releaseDate": "April 15, 2010 Patch",
-    "usedBy": ["Spy"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "6",
-    "ammoCarried": "24",
-    "reloadType": "Clip\n  ",
-    "qualities": ["Unique"],
-    "attributes": [
-      {
-        "text": "Combines style with stopping power. Long exclusive to Freelance Police, now available for other blood-thirsty mercenaries.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Ambassador",
-    "link": "/wiki/Ambassador",
-    "image": "/w/images/thumb/e/ec/Item_icon_Ambassador.png/100px-Item_icon_Ambassador.png",
-    "killIcon": "/w/images/d/dd/Killicon_ambassador.png",
-    "releaseDate": "May 21, 2009 Patch(Sniper vs. Spy Update)",
-    "usedBy": ["Spy"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "6",
-    "ammoCarried": "24",
-    "reloadType": "Clip\n  ",
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Revolver",
-        "variant": "level"
-      },
-      {
-        "text": "Crits on headshot",
-        "variant": "positive"
-      },
-      {
-        "text": "-15% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "20% slower firing speed",
-        "variant": "negative"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      },
-      {
-        "text": "Critical damage is affected by range",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "L'Etranger",
-    "link": "/wiki/L%27Etranger",
-    "image": "/w/images/thumb/b/b1/Item_icon_L%27Etranger.png/100px-Item_icon_L%27Etranger.png",
-    "killIcon": "/w/images/8/8a/Killicon_l%27etranger.png",
-    "releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
-    "usedBy": ["Spy"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "6",
-    "ammoCarried": "24",
-    "reloadType": "Clip\n  ",
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Revolver",
-        "variant": "level"
-      },
-      {
-        "text": "+40% cloak duration",
-        "variant": "positive"
-      },
-      {
-        "text": "+15% cloak on hit",
-        "variant": "positive"
-      },
-      {
-        "text": "-20% damage penalty",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Enforcer",
-    "link": "/wiki/Enforcer",
-    "image": "/w/images/thumb/b/b6/Item_icon_Enforcer.png/100px-Item_icon_Enforcer.png",
-    "killIcon": "/w/images/7/78/Killicon_enforcer.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Spy"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "6",
-    "ammoCarried": "24",
-    "reloadType": "Clip\n  ",
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Revolver",
-        "variant": "level"
-      },
-      {
-        "text": "+20% damage bonus while disguised",
-        "variant": "positive"
-      },
-      {
-        "text": "Attacks pierce damage resistance effects and bonuses",
-        "variant": "positive"
-      },
-      {
-        "text": "20% slower firing speed",
-        "variant": "negative"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Diamondback",
-    "link": "/wiki/Diamondback",
-    "image": "/w/images/thumb/b/b4/Item_icon_Diamondback.png/100px-Item_icon_Diamondback.png",
-    "killIcon": "/w/images/c/ce/Killicon_diamondback.png",
-    "releaseDate": "August 18, 2011 Patch(Manno-Technology Bundle)",
-    "usedBy": ["Spy"],
-    "slot": ["Secondary"],
-    "ammoLoaded": "6",
-    "ammoCarried": "24",
-    "reloadType": "Clip\n  ",
-    "qualities": ["Unique", "Genuine", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Revolver",
-        "variant": "level"
-      },
-      {
-        "text": "Gives one guaranteed critical hit for each\nbuilding destroyed with your sapper attached\nor backstab kill",
-        "variant": "positive"
-      },
-      {
-        "text": "-15% damage penalty",
-        "variant": "negative"
-      },
-      {
-        "text": "No random critical hits",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Knife",
-    "link": "/wiki/Knife",
-    "image": "/w/images/thumb/5/57/Item_icon_Knife.png/100px-Item_icon_Knife.png",
-    "killIcon": "/w/images/2/24/Killicon_knife.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Spy"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Normal", "Unique", "Strange", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 Knife",
-        "variant": "level"
-      },
-      {
-        "text": "Attack an enemy from behind to Backstab them for a one hit kill.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Sharp Dresser",
-    "link": "/wiki/Sharp_Dresser",
-    "image": "/w/images/thumb/e/eb/Item_icon_Sharp_Dresser.png/100px-Item_icon_Sharp_Dresser.png",
-    "killIcon": "/w/images/c/ca/Killicon_sharp_dresser.png",
-    "releaseDate": "November 23, 2011 Patch",
-    "usedBy": ["Spy"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Genuine"],
-    "attributes": [
-      {
-        "text": "Level 1 Knife",
-        "variant": "level"
-      },
-      {
-        "text": "Every merc's crazy for a sharp-dressed man. With 15th century murder-knives extruding from his cufflinks.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Black Rose",
-    "link": "/wiki/Black_Rose",
-    "image": "/w/images/thumb/3/33/Item_icon_Black_Rose.png/100px-Item_icon_Black_Rose.png",
-    "killIcon": "/w/images/6/67/Killicon_black_rose.png",
-    "releaseDate": "February 14, 2012 Patch",
-    "usedBy": ["Spy"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique"],
-    "attributes": [
-      {
-        "text": "Level 1 Knife",
-        "variant": "level"
-      },
-      {
-        "text": "Slay it with flowers.",
-        "variant": "neutral"
-      },
-      {
-        "text": "( Achievement Item: Not Tradable or Marketable )",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Your Eternal Reward",
-    "link": "/wiki/Your_Eternal_Reward",
-    "image": "/w/images/thumb/d/d3/Item_icon_Your_Eternal_Reward.png/100px-Item_icon_Your_Eternal_Reward.png",
-    "killIcon": "/w/images/6/6f/Killicon_your_eternal_reward.png",
-    "releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
-    "usedBy": ["Spy"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 Knife",
-        "variant": "level"
-      },
-      {
-        "text": "Upon a successful backstab against a human target, you rapidly disguise as your victim",
-        "variant": "positive"
-      },
-      {
-        "text": "Silent Killer: No attack noise from backstabs",
-        "variant": "positive"
-      },
-      {
-        "text": "+33% cloak drain rate",
-        "variant": "negative"
-      },
-      {
-        "text": "Normal disguises require (and consume) a full cloak meter",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Wanga Prick",
-    "link": "/wiki/Wanga_Prick",
-    "image": "/w/images/thumb/f/f5/Item_icon_Wanga_Prick.png/100px-Item_icon_Wanga_Prick.png",
-    "killIcon": "/w/images/9/97/Killicon_wanga_prick.png",
-    "releaseDate": "October 27, 2011 Patch(Very Scary Halloween Special)",
-    "usedBy": ["Spy"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Knife",
-        "variant": "level"
-      },
-      {
-        "text": "Upon a successful backstab against a human target, you rapidly disguise as your victim",
-        "variant": "positive"
-      },
-      {
-        "text": "Silent Killer: No attack noise from backstabs",
-        "variant": "positive"
-      },
-      {
-        "text": "+33% cloak drain rate",
-        "variant": "negative"
-      },
-      {
-        "text": "Normal disguises require (and consume) a full cloak meter",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Conniver's Kunai",
-    "link": "/wiki/Conniver%27s_Kunai",
-    "image": "/w/images/thumb/0/02/Item_icon_Conniver%27s_Kunai.png/100px-Item_icon_Conniver%27s_Kunai.png",
-    "killIcon": "/w/images/1/1a/Killicon_conniver%27s_kunai.png",
-    "releaseDate": "March 10, 2011 Patch(Shogun Pack)",
-    "usedBy": ["Spy"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Genuine", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 Kunai",
-        "variant": "level"
-      },
-      {
-        "text": "On Backstab: Absorbs the health from your victim",
-        "variant": "positive"
-      },
-      {
-        "text": "-55 max health on wearer",
-        "variant": "negative"
-      },
-      {
-        "text": "Start off with low health\nKill somebody with this knife\nSteal all of their health",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Big Earner",
-    "link": "/wiki/Big_Earner",
-    "image": "/w/images/thumb/c/c9/Item_icon_Big_Earner.png/100px-Item_icon_Big_Earner.png",
-    "killIcon": "/w/images/0/08/Killicon_big_earner.png",
-    "releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
-    "usedBy": ["Spy"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 Knife",
-        "variant": "level"
-      },
-      {
-        "text": "+30% cloak on kill",
-        "variant": "positive"
-      },
-      {
-        "text": "Gain a speed boost on kill",
-        "variant": "positive"
-      },
-      {
-        "text": "-25 max health on wearer",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Spy-cicle",
-    "link": "/wiki/Spy-cicle",
-    "image": "/w/images/thumb/a/a3/Item_icon_Spy-cicle.png/100px-Item_icon_Spy-cicle.png",
-    "killIcon": "/w/images/8/8d/Killicon_spy-cicle.png",
-    "releaseDate": "December 15, 2011 Patch(Australian Christmas 2011)",
-    "usedBy": ["Spy"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 Knife",
-        "variant": "level"
-      },
-      {
-        "text": "On Hit by Fire: Fireproof for 1 second and Afterburn immunity for 10 seconds",
-        "variant": "positive"
-      },
-      {
-        "text": "Backstab turns victim to ice",
-        "variant": "negative"
-      },
-      {
-        "text": "Melts in fire, regenerates in 15 seconds and by picking up ammo",
-        "variant": "negative"
-      },
-      {
-        "text": "It's the perfect gift for the man who has everything: an icicle driven into their back. Even rich people can't buy that in stores.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Enthusiast's Timepiece",
-    "link": "/wiki/Enthusiast%27s_Timepiece",
-    "image": "/w/images/thumb/1/10/Item_icon_Enthusiast%27s_Timepiece.png/100px-Item_icon_Enthusiast%27s_Timepiece.png",
-    "killIcon": null,
-    "releaseDate": "November 19, 2010 Patch",
-    "usedBy": ["Spy"],
-    "slot": ["PDA 2"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique"],
-    "attributes": [
-      {
-        "text": "Level 5 Invis Watch",
-        "variant": "level"
-      },
-      {
-        "text": "Alt-Fire: Turn invisible.  Cannot attack while invisible.  Bumping in to enemies will make you slightly visible to enemies",
-        "variant": "neutral"
-      },
-      {
-        "text": "( Achievement Item: Not Tradable or Marketable )",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Qu\u00e4ckenbirdt",
-    "link": "/wiki/Qu%C3%A4ckenbirdt",
-    "image": "/w/images/thumb/f/f6/Item_icon_Quackenbirdt.png/100px-Item_icon_Quackenbirdt.png",
-    "killIcon": null,
-    "releaseDate": "November 16, 2012 Patch",
-    "usedBy": ["Spy"],
-    "slot": ["PDA 2"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Genuine"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Invis Watch",
-        "variant": "level"
-      },
-      {
-        "text": "A marvel of German engineering, the Qu\u00e4ckenbirdt is a classically handsome two-tone Australium and tungsten spywatch for the European assassin who likes to be reminded how rich he is every time he turns invisible.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Cloak and Dagger",
-    "link": "/wiki/Cloak_and_Dagger",
-    "image": "/w/images/thumb/0/00/Item_icon_Cloak_and_Dagger.png/100px-Item_icon_Cloak_and_Dagger.png",
-    "killIcon": null,
-    "releaseDate": "May 21, 2009 Patch(Sniper vs. Spy Update)",
-    "usedBy": ["Spy"],
-    "slot": ["PDA 2"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Invis Watch",
-        "variant": "level"
-      },
-      {
-        "text": " Cloak Type: Motion Sensitive.\nAlt-Fire: Turn invisible.  Cannot attack while invisible.  Bumping in to enemies will make you slightly visible to enemies.\nCloak drain rate based on movement speed. ",
-        "variant": "neutral"
-      },
-      {
-        "text": "+100% cloak regen rate",
-        "variant": "positive"
-      },
-      {
-        "text": "No cloak meter from ammo boxes when invisible",
-        "variant": "negative"
-      },
-      {
-        "text": "-35% cloak meter from ammo boxes",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Dead Ringer",
-    "link": "/wiki/Dead_Ringer",
-    "image": "/w/images/thumb/b/b7/Item_icon_Dead_Ringer.png/100px-Item_icon_Dead_Ringer.png",
-    "killIcon": null,
-    "releaseDate": "May 21, 2009 Patch(Sniper vs. Spy Update)",
-    "usedBy": ["Spy"],
-    "slot": ["PDA 2"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Vintage", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Invis Watch",
-        "variant": "level"
-      },
-      {
-        "text": " Cloak Type: Feign Death.\nLeave a fake corpse on taking damage\nand temporarily gain invisibility, speed and damage resistance. ",
-        "variant": "neutral"
-      },
-      {
-        "text": "+50% cloak regen rate",
-        "variant": "positive"
-      },
-      {
-        "text": "+40% cloak duration",
-        "variant": "positive"
-      },
-      {
-        "text": "-50% cloak meter when Feign Death is activated",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Sapper",
-    "link": "/wiki/Sapper",
-    "image": "/w/images/thumb/6/6c/Item_icon_Sapper.png/100px-Item_icon_Sapper.png",
-    "killIcon": "/w/images/6/6a/Killicon_electro_sapper.png",
-    "releaseDate": "unknown",
-    "usedBy": ["Spy"],
-    "slot": ["Building"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Normal", "Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "Level 1 Sapper",
-        "variant": "level"
-      },
-      {
-        "text": "Place on enemy buildings to disable and slowly drain away its health.  Placing a sapper does not remove your disguise",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Ap-Sap",
-    "link": "/wiki/Ap-Sap",
-    "image": "/w/images/thumb/1/17/Item_icon_Ap-Sap.png/100px-Item_icon_Ap-Sap.png",
-    "killIcon": "/w/images/9/92/Killicon_ap-sap.png",
-    "releaseDate": "March 12, 2013 Patch",
-    "usedBy": ["Spy"],
-    "slot": ["Building"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Genuine"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Sapper",
-        "variant": "level"
-      },
-      {
-        "text": "Mann Co. got a great deal from a nice lady in an abandoned science facility on a warehouse full of slightly used, possibly mildly defective sappers. Unlike our other sappers, the Ap-Sap is sentient, and will provide hours of lively, one-sided conversation while you're trying to work.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Snack Attack",
-    "link": "/wiki/Snack_Attack",
-    "image": "/w/images/thumb/2/27/Item_icon_Snack_Attack.png/100px-Item_icon_Snack_Attack.png",
-    "killIcon": "/w/images/b/bf/Killicon_snack_attack.png",
-    "releaseDate": "June 18, 2014 Patch(Love & War Update)",
-    "usedBy": ["Spy"],
-    "slot": ["Building"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "Inspired by the TF2 Movie 'Expiration Date'",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Red-Tape Recorder",
-    "link": "/wiki/Red-Tape_Recorder",
-    "image": "/w/images/thumb/7/7d/Item_icon_Red-Tape_Recorder.png/100px-Item_icon_Red-Tape_Recorder.png",
-    "killIcon": "/w/images/f/ff/Killicon_red-tape_recorder.png",
-    "releaseDate": "August 2, 2012 Patch(Triad Pack)",
-    "usedBy": ["Spy"],
-    "slot": ["Building"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Genuine", "Strange", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Sapper",
-        "variant": "level"
-      },
-      {
-        "text": "Reverses enemy building construction",
-        "variant": "positive"
-      },
-      {
-        "text": "-100% sapper damage penalty",
-        "variant": "negative"
-      }
-    ]
-  },
-  {
-    "name": "Saxxy",
-    "link": "/wiki/Saxxy",
-    "image": "/w/images/thumb/1/18/Item_icon_Saxxy.png/100px-Item_icon_Saxxy.png",
-    "killIcon": "/w/images/e/ea/Killicon_saxxy.png",
-    "releaseDate": "June 8, 2011 Patch",
-    "usedBy": ["All classes"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Strange"],
-    "attributes": [
-      {
-        "text": "Strange Award - Kills: 0",
-        "variant": "level"
-      },
-      {
-        "text": "Winner: [Category] [Year]",
-        "variant": "positive"
-      },
-      {
-        "text": "Imbued with an ancient power",
-        "variant": "positive"
-      },
-      {
-        "text": "( Not Tradable or Marketable )",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Frying Pan",
-    "link": "/wiki/Frying_Pan",
-    "image": "/w/images/thumb/c/c1/Item_icon_Frying_Pan.png/100px-Item_icon_Frying_Pan.png",
-    "killIcon": "/w/images/6/61/Killicon_frying_pan.png",
-    "releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
-    "usedBy": ["All classes (except Engineer and Spy)"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "Level 5 Frying Pan",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Conscientious Objector",
-    "link": "/wiki/Conscientious_Objector",
-    "image": "/w/images/thumb/c/cb/Item_icon_Conscientious_Objector.png/100px-Item_icon_Conscientious_Objector.png",
-    "killIcon": "/w/images/4/4b/Killicon_conscientious_objector.png",
-    "releaseDate": "October 13, 2011 Patch(Manniversary Update & Sale)",
-    "usedBy": ["All classes (except Engineer and Spy)"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 25 Sign",
-        "variant": "level"
-      },
-      {
-        "text": "We gave peace a chance. It didn't work.\n\nCustom decals can be applied to this item.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Freedom Staff",
-    "link": "/wiki/Freedom_Staff",
-    "image": "/w/images/thumb/2/28/Item_icon_Freedom_Staff.png/100px-Item_icon_Freedom_Staff.png",
-    "killIcon": "/w/images/3/35/Killicon_freedom_staff.png",
-    "releaseDate": "September 27, 2012 Patch",
-    "usedBy": ["All classes (except Engineer and Spy)"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Genuine"],
-    "attributes": [
-      {
-        "text": "Level 25 Staff",
-        "variant": "level"
-      },
-      {
-        "text": "Since America was founded over ten thousand years ago, the noble eagle has been its symbol of freedom. Show people how much you like freedom by clubbing them senseless with a golden eagle on a stick, just like Kofi Annan.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Bat Outta Hell",
-    "link": "/wiki/Bat_Outta_Hell",
-    "image": "/w/images/thumb/c/c5/Item_icon_Bat_Outta_Hell.png/100px-Item_icon_Bat_Outta_Hell.png",
-    "killIcon": "/w/images/7/74/Killicon_bat_outta_hell.png",
-    "releaseDate": "October 26, 2012 Patch(Spectral Halloween Special)",
-    "usedBy": ["All classes (except Engineer and Spy)"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Haunted", "Collector's"],
-    "attributes": [
-      {
-        "text": "Level 5 Skull Bat",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Memory Maker",
-    "link": "/wiki/Memory_Maker",
-    "image": "/w/images/thumb/9/93/Item_icon_Memory_Maker.png/100px-Item_icon_Memory_Maker.png",
-    "killIcon": "/w/images/1/10/Killicon_memory_maker.png",
-    "releaseDate": "November 29, 2012 Patch",
-    "usedBy": ["All classes (except Engineer and Spy)"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Strange"],
-    "attributes": [
-      {
-        "text": "Strange Camera - Kills: 0",
-        "variant": "level"
-      },
-      {
-        "text": "Saxxy Nominee: [Category] [Year]",
-        "variant": "positive"
-      },
-      {
-        "text": "The memories you made as a Saxxy finalist will live on forever in film. Other memories\u2014like that time you fractured some jerk Engineer's skull with an 8mm camera\u2014will live on forever in your heart.",
-        "variant": "neutral"
-      },
-      {
-        "text": "( Not Tradable or Marketable )",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Ham Shank",
-    "link": "/wiki/Ham_Shank",
-    "image": "/w/images/thumb/6/6a/Item_icon_Ham_Shank.png/100px-Item_icon_Ham_Shank.png",
-    "killIcon": "/w/images/c/ca/Killicon_ham_shank.png",
-    "releaseDate": "March 12, 2013 Patch",
-    "usedBy": ["All classes (except Engineer and Spy)"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Genuine"],
-    "attributes": [
-      {
-        "text": "Level 5 Pork Product",
-        "variant": "level"
-      },
-      {
-        "text": "This makeshift classic is a prison staple. Simply take any common, everyday prison item, like a toothbrush or ham, whittle it to a point, and use it to shiv snitches waiting in line at the commissary for a second helping of ham and toothbrushes.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Golden Frying Pan",
-    "link": "/wiki/Golden_Frying_Pan",
-    "image": "/w/images/thumb/8/8f/Item_icon_Golden_Frying_Pan.png/100px-Item_icon_Golden_Frying_Pan.png",
-    "killIcon": "/w/images/c/cb/Killicon_golden_frying_pan.png",
-    "releaseDate": "November 21, 2013 Patch(Two Cities Update)",
-    "usedBy": ["All classes"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Strange"],
-    "attributes": [
-      {
-        "text": "Strange Golden Frying Pan - Kills: 0",
-        "variant": "level"
-      },
-      {
-        "text": "Imbued with an ancient power",
-        "variant": "positive"
-      },
-      {
-        "text": "Killstreaker: [Effect]",
-        "variant": "positive"
-      },
-      {
-        "text": "Sheen: [Color]",
-        "variant": "positive"
-      },
-      {
-        "text": "Killstreaks Active",
-        "variant": "positive"
-      }
-    ]
-  },
-  {
-    "name": "Necro Smasher",
-    "link": "/wiki/Necro_Smasher",
-    "image": "/w/images/thumb/1/1a/Item_icon_Necro_Smasher.png/100px-Item_icon_Necro_Smasher.png",
-    "killIcon": "/w/images/9/97/Killicon_necro_smasher.png",
-    "releaseDate": "October 29, 2014 Patch(Scream Fortress VI)",
-    "usedBy": ["All classes (except Spy)"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "Level 50 Hammer",
-        "variant": "level"
-      },
-      {
-        "text": "( Achievement Item: Not Tradable or Marketable )",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Crossing Guard",
-    "link": "/wiki/Crossing_Guard",
-    "image": "/w/images/thumb/8/8c/Item_icon_Crossing_Guard.png/100px-Item_icon_Crossing_Guard.png",
-    "killIcon": "/w/images/8/80/Killicon_crossing_guard.png",
-    "releaseDate": "December 8, 2014 Patch(End of the Line Update)",
-    "usedBy": ["All classes (except Engineer and Spy)"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Strange"],
-    "attributes": [
-      {
-        "text": "Level 25 Sign",
-        "variant": "level"
-      }
-    ]
-  },
-  {
-    "name": "Prinny Machete",
-    "link": "/wiki/Prinny_Machete",
-    "image": "/w/images/thumb/e/ef/Item_icon_Prinny_Machete.png/100px-Item_icon_Prinny_Machete.png",
-    "killIcon": "/w/images/b/bc/Killicon_prinny_machete.png",
-    "releaseDate": "July 7, 2016 Patch(Meet Your Match Update)",
-    "usedBy": ["All classes"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique", "Genuine"],
-    "attributes": [
-      {
-        "text": "Level 5 Machete",
-        "variant": "level"
-      },
-      {
-        "text": "( Not Usable in Crafting )",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Dragon's Fury",
-    "link": "/wiki/Dragon%27s_Fury",
-    "image": "/w/images/thumb/1/1f/Item_icon_Dragon%27s_Fury.png/75px-Item_icon_Dragon%27s_Fury.png",
-    "killIcon": "/w/images/2/20/Killicon_dragon%27s_fury.png",
-    "releaseDate": "October 20, 2017 Patch(Jungle Inferno Update)",
-    "usedBy": ["Pyro"],
-    "slot": ["Primary"],
-    "ammoLoaded": 40,
-    "ammoCarried": null,
-    "reloadType": "No reload\n  ",
-    "qualities": ["Unique", "Decorated"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Flame Launcher",
-        "variant": "level"
-      },
-      {
-        "text": "Uses a shared pressure tank for Primary\nFire and Alt-Fire.",
-        "variant": "neutral"
-      },
-      {
-        "text": "Primary Fire: Launches a fast-moving\nprojectile that briefly ignites enemies",
-        "variant": "neutral"
-      },
-      {
-        "text": "Alt-Fire: Release a blast of air that\npushes enemies and projectiles, and\nextinguishes teammates that are on fire.",
-        "variant": "neutral"
-      },
-      {
-        "text": "Extinguishing teammates restores 20\nhealth",
-        "variant": "positive"
-      },
-      {
-        "text": "Deals 300% damage to burning players\n+50% re-pressurization rate on hit",
-        "variant": "positive"
-      },
-      {
-        "text": "-50% repressurization rate on Alt-Fire",
-        "variant": "negative"
-      },
-      {
-        "text": "This powerful, single-shot flamethrower\nrewards consecutive hits with faster\nreloads and bonus damage.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Gas Passer",
-    "link": "/wiki/Gas_Passer",
-    "image": "/w/images/thumb/1/1f/Item_icon_Dragon%27s_Fury.png/75px-Item_icon_Dragon%27s_Fury.png",
-    "killIcon": null,
-    "releaseDate": "October 20, 2017 Patch(Jungle Inferno Update)",
-    "usedBy": ["Pyro"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "Recharge (60 seconds max)\n  ",
-    "qualities": ["Unique"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Gas-Like Substance",
-        "variant": "level"
-      },
-      {
-        "text": "Gas meter builds with damage done\nand/or time",
-        "variant": "positive"
-      },
-      {
-        "text": "Spawning and resupply do not affect\nthe Gas meter\nGas meter starts empty",
-        "variant": "negative"
-      },
-      {
-        "text": "Creates a horrific visible gas cloud that\ncoats enemies with a flammable\nmaterial, which then ignites into\nafterburn if they take damage (even\nenemy Pyros!)",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Hot Hand",
-    "link": "/wiki/Hot_Hand",
-    "image": "/w/images/thumb/f/f6/Item_icon_Hot_Hand.png/75px-Item_icon_Hot_Hand.png",
-    "killIcon": "/w/images/8/8a/Killicon_hot_hand.png",
-    "releaseDate": "October 20, 2017 Patch(Jungle Inferno Update)",
-    "usedBy": ["Pyro"],
-    "slot": ["Melee"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": null,
-    "qualities": ["Unique"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Slap",
-        "variant": "level"
-      },
-      {
-        "text": "Gain a speed boost when you hit an\nenemy player",
-        "variant": "positive"
-      },
-      {
-        "text": "-20% damage penalty",
-        "variant": "negaitve"
-      },
-      {
-        "text": "This melee slap tells your opponent, and\nanyone watching the kill feed, that your\nhand just gave some lucky face the gift of\nslapping it stupid.",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Thermal Thruster",
-    "link": "/wiki/Thermal_Thruster",
-    "image": "/w/images/thumb/0/00/Item_icon_Thermal_Thruster.png/75px-Item_icon_Thermal_Thruster.png",
-    "killIcon": "/w/images/a/ac/Killicon_mantreads.png",
-    "releaseDate": "October 20, 2017 Patch(Jungle Inferno Update)",
-    "usedBy": ["Pyro"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "Recharge (15 Seconds per charge)\n  ",
-    "qualities": ["Unique"],
-    "attributes": [
-      {
-        "text": "Level 1 - 100 Rocket Pack",
-        "variant": "level"
-      },
-      {
-        "text": "Push enemies back when you land\n(force and radius based on velocity)",
-        "variant": "neutral"
-      },
-      {
-        "text": "Death from above! Fires a short-duration\nblast that launches the Pyro in the\ndirection they are aiming. Deal 3x falling\ndamage to anyone you land on!",
-        "variant": "neutral"
-      }
-    ]
-  },
-  {
-    "name": "Second Banana",
-    "link": "/wiki/Second_Banana",
-    "image": "/w/images/thumb/7/77/Item_icon_Second_Banana.png/75px-Item_icon_Second_Banana.png",
-    "killIcon": null,
-    "releaseDate": "October 20, 2017 Patch(Jungle Inferno Update)",
-    "usedBy": ["Heavy"],
-    "slot": ["Secondary"],
-    "ammoLoaded": null,
-    "ammoCarried": null,
-    "reloadType": "Recharge (10 Seconds)\n  ",
-    "qualities": ["Unique"],
-    "attributes": [
-      {
-        "text": "Level 1 Lunch Box",
-        "variant": "level"
-      },
-      {
-        "text": "+50% increase in charge recharge rate",
-        "variant": "positive"
-      },
-      {
-        "text": "-33% healing effect",
-        "variant": "negative"
-      },
-      {
-        "text": "Eat to gain up to 100 health.\nAlt-fire: Share chocolate with a friend (Small\nHealth Kit)",
-        "variant": "neutral"
-      }
-    ]
-  }
+	{
+		"name": "Scattergun",
+		"link": "/wiki/Scattergun",
+		"image": "/w/images/thumb/1/1b/Item_icon_Scattergun.png/100px-Item_icon_Scattergun.png",
+		"killIcon": "/w/images/3/34/Killicon_scattergun.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Scout"],
+		"slot": ["Primary"],
+		"ammoLoaded": "6",
+		"ammoCarried": "32",
+		"reloadType": "Single\n  ",
+		"qualities": ["Normal", "Unique", "Strange", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 Scattergun",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Force-A-Nature",
+		"link": "/wiki/Force-A-Nature",
+		"image": "/w/images/thumb/e/ed/Item_icon_Force-A-Nature.png/100px-Item_icon_Force-A-Nature.png",
+		"killIcon": "/w/images/5/51/Killicon_force-a-nature.png",
+		"releaseDate": "February 24, 2009 Patch(Scout Update)",
+		"usedBy": ["Scout"],
+		"slot": ["Primary"],
+		"ammoLoaded": "2",
+		"ammoCarried": "32",
+		"reloadType": "Clip\n  ",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Scattergun",
+				"variant": "level"
+			},
+			{
+				"text": "+50% faster firing speed",
+				"variant": "positive"
+			},
+			{
+				"text": "Knockback on the target and shooter",
+				"variant": "positive"
+			},
+			{
+				"text": "+20% bullets per shot",
+				"variant": "positive"
+			},
+			{
+				"text": "-10% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "-66% clip size",
+				"variant": "negative"
+			},
+			{
+				"text": "This weapon reloads its entire clip at once",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Shortstop",
+		"link": "/wiki/Shortstop",
+		"image": "/w/images/thumb/8/84/Item_icon_Shortstop.png/100px-Item_icon_Shortstop.png",
+		"killIcon": "/w/images/2/2b/Killicon_shortstop.png",
+		"releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
+		"usedBy": ["Scout"],
+		"slot": ["Primary"],
+		"ammoLoaded": "4",
+		"ammoCarried": "32",
+		"reloadType": "Clip\n  ",
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 Peppergun",
+				"variant": "level"
+			},
+			{
+				"text": " When weapon is active: ",
+				"variant": "neutral"
+			},
+			{
+				"text": "Increase in push force taken from damage and airblast",
+				"variant": "negative"
+			},
+			{
+				"text": "Holds a 4-shot clip and reloads its entire clip at once.\nAlt-Fire to reach and shove someone!\n\nMann Co.'s latest in high attitude\nbreak-action personal defense.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Soda Popper",
+		"link": "/wiki/Soda_Popper",
+		"image": "/w/images/thumb/f/f1/Item_icon_Soda_Popper.png/100px-Item_icon_Soda_Popper.png",
+		"killIcon": "/w/images/3/34/Killicon_soda_popper.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Scout"],
+		"slot": ["Primary"],
+		"ammoLoaded": "2",
+		"ammoCarried": "32",
+		"reloadType": "Clip\n  ",
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 10 Scattergun",
+				"variant": "level"
+			},
+			{
+				"text": "+50% faster firing speed",
+				"variant": "positive"
+			},
+			{
+				"text": "25% faster reload time",
+				"variant": "positive"
+			},
+			{
+				"text": "On Hit: Builds Hype",
+				"variant": "positive"
+			},
+			{
+				"text": "-66% clip size",
+				"variant": "negative"
+			},
+			{
+				"text": "When Hype is full, Alt-Fire to activate Hype mode for multiple air jumps.\nThis weapon reloads its entire clip at once.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Baby Face's Blaster",
+		"link": "/wiki/Baby_Face%27s_Blaster",
+		"image": "/w/images/thumb/e/e6/Item_icon_Baby_Face%27s_Blaster.png/100px-Item_icon_Baby_Face%27s_Blaster.png",
+		"killIcon": "/w/images/5/56/Killicon_baby_face%27s_blaster.png",
+		"releaseDate": "June 27, 2012 Patch(Pyromania Update)",
+		"usedBy": ["Scout"],
+		"slot": ["Primary"],
+		"ammoLoaded": "4",
+		"ammoCarried": "32",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Scattergun",
+				"variant": "level"
+			},
+			{
+				"text": "On Hit: Builds Boost\nRun speed increased with Boost",
+				"variant": "positive"
+			},
+			{
+				"text": "-34% clip size",
+				"variant": "negative"
+			},
+			{
+				"text": "10% slower move speed on wearer",
+				"variant": "negative"
+			},
+			{
+				"text": "Boost reduced on air jumps",
+				"variant": "negative"
+			},
+			{
+				"text": "Boost reduced when hit",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Back Scatter",
+		"link": "/wiki/Back_Scatter",
+		"image": "/w/images/thumb/1/11/Item_icon_Back_Scatter.png/100px-Item_icon_Back_Scatter.png",
+		"killIcon": "/w/images/b/b9/Killicon_back_scatter.png",
+		"releaseDate": "June 18, 2014 Patch(Love & War Update)",
+		"usedBy": ["Scout"],
+		"slot": ["Primary"],
+		"ammoLoaded": "4",
+		"ammoCarried": "32",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Scattergun",
+				"variant": "level"
+			},
+			{
+				"text": "Mini-crits targets when fired at their back from close range",
+				"variant": "positive"
+			},
+			{
+				"text": "-34% clip size",
+				"variant": "negative"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "20% less accurate",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Pistol",
+		"link": "/wiki/Pistol",
+		"image": "/w/images/thumb/5/52/Item_icon_Pistol.png/100px-Item_icon_Pistol.png",
+		"killIcon": "/w/images/1/1a/Killicon_pistol.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Scout", "Engineer"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "12",
+		"ammoCarried": "36 (Scout)200 (Engineer)",
+		"reloadType": "Clip\n  ",
+		"qualities": ["Normal", "Unique", "Strange", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 Pistol",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Lugermorph",
+		"link": "/wiki/Lugermorph",
+		"image": "/w/images/thumb/8/86/Item_icon_Lugermorph.png/100px-Item_icon_Lugermorph.png",
+		"killIcon": "/w/images/e/e7/Killicon_lugermorph.png",
+		"releaseDate": "April 15, 2010 Patch",
+		"usedBy": ["Scout", "Engineer"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "12",
+		"ammoCarried": "36 (Scout)200 (Engineer)",
+		"reloadType": "Clip\n  ",
+		"qualities": ["Unique", "Vintage"],
+		"attributes": [
+			{
+				"text": "Level 5 Pistol",
+				"variant": "level"
+			},
+			{
+				"text": "The ultimate in semi-concealed weaponry. There's no question you need this gun, the only question is: where will you keep it?",
+				"variant": "neutral"
+			},
+			{
+				"text": "( Achievement Item: Not Tradable or Marketable )",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "C.A.P.P.E.R",
+		"link": "/wiki/C.A.P.P.E.R",
+		"image": "/w/images/thumb/a/a6/Item_icon_C.A.P.P.E.R.png/100px-Item_icon_C.A.P.P.E.R.png",
+		"killIcon": "/w/images/e/e0/Killicon_c.a.p.p.e.r.png",
+		"releaseDate": "October 6, 2015 Patch(Invasion Community Update)",
+		"usedBy": ["Scout", "Engineer"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "12",
+		"ammoCarried": "36 (Scout)200 (Engineer)",
+		"reloadType": "Clip\n  ",
+		"qualities": ["Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "\nPistol",
+				"variant": "level"
+			},
+			{
+				"text": "Turn your enemies in to ash!",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Winger",
+		"link": "/wiki/Winger",
+		"image": "/w/images/thumb/4/4e/Item_icon_Winger.png/100px-Item_icon_Winger.png",
+		"killIcon": "/w/images/3/35/Killicon_winger.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Scout"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "5",
+		"ammoCarried": "36",
+		"reloadType": "Clip\n  ",
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 15 Pistol",
+				"variant": "level"
+			},
+			{
+				"text": "+15% damage bonus",
+				"variant": "positive"
+			},
+			{
+				"text": "+25% greater jump height when active",
+				"variant": "positive"
+			},
+			{
+				"text": "-60% clip size",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Pretty Boy's Pocket Pistol",
+		"link": "/wiki/Pretty_Boy%27s_Pocket_Pistol",
+		"image": "/w/images/thumb/f/f6/Item_icon_Pretty_Boy%27s_Pocket_Pistol.png/100px-Item_icon_Pretty_Boy%27s_Pocket_Pistol.png",
+		"killIcon": "/w/images/b/b8/Killicon_pretty_boy%27s_pocket_pistol.png",
+		"releaseDate": "June 27, 2012 Patch(Pyromania Update)",
+		"usedBy": ["Scout"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "9",
+		"ammoCarried": "36",
+		"reloadType": "Clip\n  ",
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Pistol",
+				"variant": "level"
+			},
+			{
+				"text": " When weapon is active: ",
+				"variant": "neutral"
+			},
+			{
+				"text": "+15% faster firing speed",
+				"variant": "positive"
+			},
+			{
+				"text": "On Hit: Gain up to +3 health",
+				"variant": "positive"
+			},
+			{
+				"text": "-25% clip size",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Flying Guillotine",
+		"link": "/wiki/Flying_Guillotine",
+		"image": "/w/images/thumb/5/5a/Item_icon_Flying_Guillotine.png/100px-Item_icon_Flying_Guillotine.png",
+		"killIcon": "/w/images/f/ff/Killicon_flying_guillotine.png",
+		"releaseDate": "August 2, 2012 Patch(Triad Pack)",
+		"usedBy": ["Scout"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Genuine", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Cleaver",
+				"variant": "level"
+			},
+			{
+				"text": "Throw at your enemies to make them bleed!  Long distance hits reduce recharge time",
+				"variant": "positive"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Bonk! Atomic Punch",
+		"link": "/wiki/Bonk!_Atomic_Punch",
+		"image": "/w/images/thumb/8/8f/Item_icon_Bonk%21_Atomic_Punch.png/100px-Item_icon_Bonk%21_Atomic_Punch.png",
+		"killIcon": null,
+		"releaseDate": "February 24, 2009 Patch(Scout Update)",
+		"usedBy": ["Scout"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "Recharge (30 seconds)\n",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Lunch Box",
+				"variant": "level"
+			},
+			{
+				"text": "Drink to become invulnerable for 8 seconds.  Cannot attack during this time.\nDamage absorbed will slow you when the effect ends.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Crit-a-Cola",
+		"link": "/wiki/Crit-a-Cola",
+		"image": "/w/images/thumb/a/ae/Item_icon_Crit-a-Cola.png/100px-Item_icon_Crit-a-Cola.png",
+		"killIcon": null,
+		"releaseDate": "April 28, 2010 Patch",
+		"usedBy": ["Scout"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "Recharge (22 seconds)\n",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Lunch Box",
+				"variant": "level"
+			},
+			{
+				"text": "While effect is active: Each attack mini-crits and sets Marked-For-Death for 5 seconds.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Mad Milk",
+		"link": "/wiki/Mad_Milk",
+		"image": "/w/images/thumb/5/56/Item_icon_Mad_Milk.png/100px-Item_icon_Mad_Milk.png",
+		"killIcon": null,
+		"releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
+		"usedBy": ["Scout"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "Recharge (20 seconds)\n",
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Non-Milk Substance",
+				"variant": "level"
+			},
+			{
+				"text": "Extinguishing teammates reduces cooldown by -20%",
+				"variant": "positive"
+			},
+			{
+				"text": "Players heal 60% of the damage done\nto an enemy covered with milk.\nCan be used to extinguish fires.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Mutated Milk",
+		"link": "/wiki/Mutated_Milk",
+		"image": "/w/images/thumb/b/bd/Item_icon_Mutated_Milk.png/100px-Item_icon_Mutated_Milk.png",
+		"killIcon": null,
+		"releaseDate": "June 18, 2014 Patch(Love & War Update)",
+		"usedBy": ["Scout"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "Recharge (20 seconds)\n",
+		"qualities": ["Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "Extinguishing teammates reduces cooldown by -20%",
+				"variant": "positive"
+			},
+			{
+				"text": "Players heal 60% of the damage done to an enemy covered with milk.\n\nInspired by the TF2 Movie 'Expiration Date'",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Bat",
+		"link": "/wiki/Bat",
+		"image": "/w/images/thumb/b/b5/Item_icon_Bat.png/100px-Item_icon_Bat.png",
+		"killIcon": "/w/images/d/de/Killicon_bat.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Scout"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Normal", "Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "Level 1 Bat",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Holy Mackerel",
+		"link": "/wiki/Holy_Mackerel",
+		"image": "/w/images/thumb/8/86/Item_icon_Holy_Mackerel.png/100px-Item_icon_Holy_Mackerel.png",
+		"killIcon": "/w/images/e/e7/Killicon_holy_mackerel.png",
+		"releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
+		"usedBy": ["Scout"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 42 Fish",
+				"variant": "level"
+			},
+			{
+				"text": "Getting hit by a fish has got to be humiliating.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Unarmed Combat",
+		"link": "/wiki/Unarmed_Combat",
+		"image": "/w/images/thumb/9/96/Item_icon_Unarmed_Combat.png/100px-Item_icon_Unarmed_Combat.png",
+		"killIcon": "/w/images/d/db/Killicon_unarmed_combat.png",
+		"releaseDate": "October 27, 2011 Patch(Very Scary Halloween Special)",
+		"usedBy": ["Scout"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Severed Arm",
+				"variant": "level"
+			},
+			{
+				"text": "So nice of the Spy to lend an arm...",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Batsaber",
+		"link": "/wiki/Batsaber",
+		"image": "/w/images/thumb/e/ef/Item_icon_Batsaber.png/100px-Item_icon_Batsaber.png",
+		"killIcon": "/w/images/2/29/Killicon_batsaber.png",
+		"releaseDate": "October 6, 2015 Patch(Invasion Community Update)",
+		"usedBy": ["Scout"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "\nBat",
+				"variant": "level"
+			},
+			{
+				"text": "Energy Overwhelming!\nDisintegrate your enemies!",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Sandman",
+		"link": "/wiki/Sandman",
+		"image": "/w/images/thumb/7/70/Item_icon_Sandman.png/100px-Item_icon_Sandman.png",
+		"killIcon": "/w/images/2/2c/Killicon_sandman.png",
+		"releaseDate": "February 24, 2009 Patch(Scout Update)",
+		"usedBy": ["Scout"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "Recharge (10 Seconds)\n",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 15 Bat",
+				"variant": "level"
+			},
+			{
+				"text": "Alt-Fire: Launches a ball that slows opponents",
+				"variant": "positive"
+			},
+			{
+				"text": "-15 max health on wearer",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Candy Cane",
+		"link": "/wiki/Candy_Cane",
+		"image": "/w/images/thumb/0/05/Item_icon_Candy_Cane.png/100px-Item_icon_Candy_Cane.png",
+		"killIcon": "/w/images/d/d1/Killicon_candy_cane.png",
+		"releaseDate": "December 17, 2010 Patch(Australian Christmas)",
+		"usedBy": ["Scout"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 25 Bat",
+				"variant": "level"
+			},
+			{
+				"text": "On Kill: A small health pack is dropped",
+				"variant": "positive"
+			},
+			{
+				"text": "25% explosive damage vulnerability on wearer",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Boston Basher",
+		"link": "/wiki/Boston_Basher",
+		"image": "/w/images/thumb/b/b5/Item_icon_Boston_Basher.png/100px-Item_icon_Boston_Basher.png",
+		"killIcon": "/w/images/f/f1/Killicon_boston_basher.png",
+		"releaseDate": "December 17, 2010 Patch(Australian Christmas)",
+		"usedBy": ["Scout"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 25 Bat",
+				"variant": "level"
+			},
+			{
+				"text": "On Hit: Bleed for 5 seconds",
+				"variant": "positive"
+			},
+			{
+				"text": "On Miss: Hit yourself. Idiot.",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Three-Rune Blade",
+		"link": "/wiki/Three-Rune_Blade",
+		"image": "/w/images/thumb/f/f6/Item_icon_Three-Rune_Blade.png/100px-Item_icon_Three-Rune_Blade.png",
+		"killIcon": "/w/images/9/9d/Killicon_three-rune_blade.png",
+		"releaseDate": "May 12, 2011 Patch",
+		"usedBy": ["Scout"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Genuine"],
+		"attributes": [
+			{
+				"text": "Level 10 Sword",
+				"variant": "level"
+			},
+			{
+				"text": "On Hit: Bleed for 5 seconds",
+				"variant": "positive"
+			},
+			{
+				"text": "On Miss: Hit yourself. Idiot.",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Sun-on-a-Stick",
+		"link": "/wiki/Sun-on-a-Stick",
+		"image": "/w/images/thumb/0/06/Item_icon_Sun-on-a-Stick.png/100px-Item_icon_Sun-on-a-Stick.png",
+		"killIcon": "/w/images/0/00/Killicon_sun-on-a-stick.png",
+		"releaseDate": "February 3, 2011 Patch",
+		"usedBy": ["Scout"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Genuine", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 RIFT Fire Mace",
+				"variant": "level"
+			},
+			{
+				"text": "100% critical hit vs burning players",
+				"variant": "positive"
+			},
+			{
+				"text": "+25% fire damage resistance while deployed",
+				"variant": "positive"
+			},
+			{
+				"text": "-25% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "Spiky end goes into other man.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Fan O'War",
+		"link": "/wiki/Fan_O%27War",
+		"image": "/w/images/thumb/f/f4/Item_icon_Fan_O%27War.png/100px-Item_icon_Fan_O%27War.png",
+		"killIcon": "/w/images/6/65/Killicon_fan_o%27war.png",
+		"releaseDate": "March 10, 2011 Patch(Shogun Pack)",
+		"usedBy": ["Scout"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Genuine", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Gunbai",
+				"variant": "level"
+			},
+			{
+				"text": "Crits whenever it would normally mini-crit",
+				"variant": "positive"
+			},
+			{
+				"text": "On Hit: One target at a time is Marked-For-Death, causing all damage taken to be mini-crits",
+				"variant": "positive"
+			},
+			{
+				"text": "-75% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "Winds of Gravel Pit\nScout brings on his deadly fan!\nYou are Marked-For-Death",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Atomizer",
+		"link": "/wiki/Atomizer",
+		"image": "/w/images/thumb/2/29/Item_icon_Atomizer.png/100px-Item_icon_Atomizer.png",
+		"killIcon": "/w/images/b/b1/Killicon_atomizer.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Scout"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Bat",
+				"variant": "level"
+			},
+			{
+				"text": "Grants Triple Jump while deployed.\nMelee attacks mini-crit while airborne.",
+				"variant": "positive"
+			},
+			{
+				"text": "-15% damage vs players",
+				"variant": "negative"
+			},
+			{
+				"text": "This weapon deploys 50% slower",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Wrap Assassin",
+		"link": "/wiki/Wrap_Assassin",
+		"image": "/w/images/thumb/6/6b/Item_icon_Wrap_Assassin.png/100px-Item_icon_Wrap_Assassin.png",
+		"killIcon": "/w/images/7/79/Killicon_wrap_assassin.png",
+		"releaseDate": "December 15, 2011 Patch(Australian Christmas 2011)",
+		"usedBy": ["Scout"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 15 Bat",
+				"variant": "level"
+			},
+			{
+				"text": "+25% increase in recharge rate",
+				"variant": "positive"
+			},
+			{
+				"text": "Alt-Fire: Launches a festive ornament that shatters causing bleed",
+				"variant": "positive"
+			},
+			{
+				"text": "-65% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "These lovely festive ornaments are so beautifully crafted, your enemies are going to want to see them close up. Indulge them by batting those fragile glass bulbs into their eyes at 90 mph.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Rocket Launcher",
+		"link": "/wiki/Rocket_Launcher",
+		"image": "/w/images/thumb/f/fe/Item_icon_Rocket_Launcher.png/100px-Item_icon_Rocket_Launcher.png",
+		"killIcon": "/w/images/8/8c/Killicon_rocket_launcher.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Soldier"],
+		"slot": ["Primary"],
+		"ammoLoaded": "4",
+		"ammoCarried": "20  / 36",
+		"reloadType": "Single\n  ",
+		"qualities": ["Normal", "Unique", "Strange", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 Rocket Launcher",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Original",
+		"link": "/wiki/Original",
+		"image": "/w/images/thumb/8/88/Item_icon_Original.png/100px-Item_icon_Original.png",
+		"killIcon": "/w/images/e/e0/Killicon_original.png",
+		"releaseDate": "August 3, 2011 Patch",
+		"usedBy": ["Soldier"],
+		"slot": ["Primary"],
+		"ammoLoaded": "4",
+		"ammoCarried": "20",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Genuine", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Rocket Launcher",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Direct Hit",
+		"link": "/wiki/Direct_Hit",
+		"image": "/w/images/thumb/e/e7/Item_icon_Direct_Hit.png/100px-Item_icon_Direct_Hit.png",
+		"killIcon": "/w/images/1/16/Killicon_direct_hit.png",
+		"releaseDate": "December 17, 2009 Patch(WAR! Update)",
+		"usedBy": ["Soldier"],
+		"slot": ["Primary"],
+		"ammoLoaded": "4",
+		"ammoCarried": "20",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 Rocket Launcher",
+				"variant": "level"
+			},
+			{
+				"text": "+25% damage bonus",
+				"variant": "positive"
+			},
+			{
+				"text": "+80% projectile speed",
+				"variant": "positive"
+			},
+			{
+				"text": "Mini-crits targets launched airborne by explosions, grapple hooks or rocket packs",
+				"variant": "positive"
+			},
+			{
+				"text": "-70% explosion radius",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Black Box",
+		"link": "/wiki/Black_Box",
+		"image": "/w/images/thumb/d/d2/Item_icon_Black_Box.png/100px-Item_icon_Black_Box.png",
+		"killIcon": "/w/images/5/56/Killicon_black_box.png",
+		"releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
+		"usedBy": ["Soldier"],
+		"slot": ["Primary"],
+		"ammoLoaded": "3",
+		"ammoCarried": "20",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 5 Rocket Launcher",
+				"variant": "level"
+			},
+			{
+				"text": "On Hit: Gain up to +20 health per attack",
+				"variant": "positive"
+			},
+			{
+				"text": "-25% clip size",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Rocket Jumper",
+		"link": "/wiki/Rocket_Jumper",
+		"image": "/w/images/thumb/5/53/Item_icon_Rocket_Jumper.png/100px-Item_icon_Rocket_Jumper.png",
+		"killIcon": null,
+		"releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
+		"usedBy": ["Soldier"],
+		"slot": ["Primary"],
+		"ammoLoaded": "4",
+		"ammoCarried": "60",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 Rocket Launcher",
+				"variant": "level"
+			},
+			{
+				"text": "+200% max primary ammo on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "No self inflicted blast damage taken",
+				"variant": "positive"
+			},
+			{
+				"text": "-100% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "Wearer cannot carry the intelligence briefcase or PASS Time JACK",
+				"variant": "negative"
+			},
+			{
+				"text": "A special rocket launcher for learning\nrocket jump tricks and patterns.\nThis weapon deals ZERO damage.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Liberty Launcher",
+		"link": "/wiki/Liberty_Launcher",
+		"image": "/w/images/thumb/2/24/Item_icon_Liberty_Launcher.png/100px-Item_icon_Liberty_Launcher.png",
+		"killIcon": "/w/images/7/77/Killicon_liberty_launcher.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Soldier"],
+		"slot": ["Primary"],
+		"ammoLoaded": "5",
+		"ammoCarried": "20",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 25 Rocket Launcher",
+				"variant": "level"
+			},
+			{
+				"text": "+25% clip size",
+				"variant": "positive"
+			},
+			{
+				"text": "+40% projectile speed",
+				"variant": "positive"
+			},
+			{
+				"text": "-25% blast damage from rocket jumps",
+				"variant": "positive"
+			},
+			{
+				"text": "-25% damage penalty",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Cow Mangler 5000",
+		"link": "/wiki/Cow_Mangler_5000",
+		"image": "/w/images/thumb/4/46/Item_icon_Cow_Mangler_5000.png/100px-Item_icon_Cow_Mangler_5000.png",
+		"killIcon": "/w/images/9/94/Killicon_cow_mangler_5000.png",
+		"releaseDate": "July 20, 2011 Patch(Dr. Grordbort's Victory Pack Update)",
+		"usedBy": ["Soldier"],
+		"slot": ["Primary"],
+		"ammoLoaded": "4",
+		"ammoCarried": "Unlimited",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 30 Focused Wave Projector",
+				"variant": "level"
+			},
+			{
+				"text": "Does not require ammo",
+				"variant": "positive"
+			},
+			{
+				"text": "Alt-Fire: A charged shot that\nmini-crits players, sets them on fire\nand disables buildings for 4 sec",
+				"variant": "positive"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "Deals only 20% damage to buildings",
+				"variant": "negative"
+			},
+			{
+				"text": "Minicrits whenever it would normally crit",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Beggar's Bazooka",
+		"link": "/wiki/Beggar%27s_Bazooka",
+		"image": "/w/images/thumb/7/77/Item_icon_Beggar%27s_Bazooka.png/100px-Item_icon_Beggar%27s_Bazooka.png",
+		"killIcon": "/w/images/7/7d/Killicon_beggar%27s_bazooka.png",
+		"releaseDate": "June 27, 2012 Patch(Pyromania Update)",
+		"usedBy": ["Soldier"],
+		"slot": ["Primary"],
+		"ammoLoaded": "0",
+		"ammoCarried": "20",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Rocket Launcher",
+				"variant": "level"
+			},
+			{
+				"text": "Hold Fire to load up to three rockets\nRelease Fire to unleash the barrage",
+				"variant": "positive"
+			},
+			{
+				"text": "-20% explosion radius",
+				"variant": "negative"
+			},
+			{
+				"text": "+3 degrees random projectile deviation",
+				"variant": "negative"
+			},
+			{
+				"text": "Overloading the chamber will cause a misfire",
+				"variant": "negative"
+			},
+			{
+				"text": "No ammo from dispensers when active",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Air Strike",
+		"link": "/wiki/Air_Strike",
+		"image": "/w/images/thumb/f/f8/Item_icon_Air_Strike.png/100px-Item_icon_Air_Strike.png",
+		"killIcon": "/w/images/d/dc/Killicon_air_strike.png",
+		"releaseDate": "June 18, 2014 Patch(Love & War Update)",
+		"usedBy": ["Soldier"],
+		"slot": ["Primary"],
+		"ammoLoaded": "4-8",
+		"ammoCarried": "20",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Rocket Launcher",
+				"variant": "level"
+			},
+			{
+				"text": "-15% blast damage from rocket jumps",
+				"variant": "positive"
+			},
+			{
+				"text": "Increased attack speed and smaller blast radius while blast jumping",
+				"variant": "positive"
+			},
+			{
+				"text": "Clip size increased on kill",
+				"variant": "positive"
+			},
+			{
+				"text": "-15% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "-10% explosion radius",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Shotgun",
+		"link": "/wiki/Shotgun",
+		"image": "/w/images/thumb/5/5f/Item_icon_Shotgun.png/100px-Item_icon_Shotgun.png",
+		"killIcon": "/w/images/6/61/Killicon_shotgun.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Engineer", "Soldier", "Pyro", "Heavy"],
+		"slot": ["Primary", "Secondary"],
+		"ammoLoaded": "6",
+		"ammoCarried": "32",
+		"reloadType": "Single\n  ",
+		"qualities": ["Normal", "Unique", "Strange", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 Shotgun",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Reserve Shooter",
+		"link": "/wiki/Reserve_Shooter",
+		"image": "/w/images/thumb/3/34/Item_icon_Reserve_Shooter.png/100px-Item_icon_Reserve_Shooter.png",
+		"killIcon": "/w/images/6/68/Killicon_reserve_shooter.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Soldier", "Pyro"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "4",
+		"ammoCarried": "32",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 10 Shotgun",
+				"variant": "level"
+			},
+			{
+				"text": "Mini-crits targets launched airborne by explosions, grapple hooks or rocket packs",
+				"variant": "positive"
+			},
+			{
+				"text": "This weapon deploys 20% faster",
+				"variant": "positive"
+			},
+			{
+				"text": "-34% clip size",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Buff Banner",
+		"link": "/wiki/Buff_Banner",
+		"image": "/w/images/thumb/7/7c/Item_icon_Buff_Banner.png/100px-Item_icon_Buff_Banner.png",
+		"killIcon": null,
+		"releaseDate": "December 17, 2009 Patch(WAR! Update)",
+		"usedBy": ["Soldier"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Battle Banner",
+				"variant": "level"
+			},
+			{
+				"text": "Provides an offensive buff that causes\nnearby team members to do mini-crits.\nRage increases through damage done.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Gunboats",
+		"link": "/wiki/Gunboats",
+		"image": "/w/images/thumb/0/0c/Item_icon_Gunboats.png/100px-Item_icon_Gunboats.png",
+		"killIcon": null,
+		"releaseDate": "December 17, 2009 Patch(WAR! Update)",
+		"usedBy": ["Soldier"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Boots",
+				"variant": "level"
+			},
+			{
+				"text": "-60% blast damage from rocket jumps",
+				"variant": "positive"
+			}
+		]
+	},
+	{
+		"name": "Battalion's Backup",
+		"link": "/wiki/Battalion%27s_Backup",
+		"image": "/w/images/thumb/d/d8/Item_icon_Battalion%27s_Backup.png/100px-Item_icon_Battalion%27s_Backup.png",
+		"killIcon": null,
+		"releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
+		"usedBy": ["Soldier"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Battle Banner",
+				"variant": "level"
+			},
+			{
+				"text": "+20 max health on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "Provides a defensive buff that protects\nnearby team members from crits,\nincoming sentry damage by 50%\nand 35% from all other sources.\nRage increases through damage done.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Concheror",
+		"link": "/wiki/Concheror",
+		"image": "/w/images/thumb/7/7e/Item_icon_Concheror.png/100px-Item_icon_Concheror.png",
+		"killIcon": null,
+		"releaseDate": "March 10, 2011 Patch(Shogun Pack)",
+		"usedBy": ["Soldier"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Genuine", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Sashimono",
+				"variant": "level"
+			},
+			{
+				"text": "+4 health regenerated per second on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "Provides group speed buff\nwith damage done giving health.\nGain rage with damage.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Mantreads",
+		"link": "/wiki/Mantreads",
+		"image": "/w/images/thumb/6/6a/Item_icon_Mantreads.png/100px-Item_icon_Mantreads.png",
+		"killIcon": "/w/images/a/ac/Killicon_mantreads.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Soldier"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Boots",
+				"variant": "level"
+			},
+			{
+				"text": "-75% reduction in push force taken from damage",
+				"variant": "positive"
+			},
+			{
+				"text": "Deals 3x falling damage to the player you land on",
+				"variant": "positive"
+			},
+			{
+				"text": "-75% reduction in airblast vulnerability",
+				"variant": "positive"
+			},
+			{
+				"text": "200% increased air control when blast jumping",
+				"variant": "positive"
+			}
+		]
+	},
+	{
+		"name": "Righteous Bison",
+		"link": "/wiki/Righteous_Bison",
+		"image": "/w/images/thumb/1/1d/Item_icon_Righteous_Bison.png/100px-Item_icon_Righteous_Bison.png",
+		"killIcon": "/w/images/a/a4/Killicon_righteous_bison.png",
+		"releaseDate": "July 20, 2011 Patch(Dr. Grordbort's Victory Pack Update)",
+		"usedBy": ["Soldier"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "4",
+		"ammoCarried": "Unlimited",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Genuine", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 30 Indivisible Particle Smasher",
+				"variant": "level"
+			},
+			{
+				"text": "Does not require ammo",
+				"variant": "positive"
+			},
+			{
+				"text": "Projectile penetrates enemy targets",
+				"variant": "positive"
+			},
+			{
+				"text": "Projectile cannot be deflected",
+				"variant": "positive"
+			},
+			{
+				"text": "Deals only 20% damage to buildings",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "B.A.S.E. Jumper",
+		"link": "/wiki/B.A.S.E._Jumper",
+		"image": "/w/images/thumb/b/b2/Item_icon_B.A.S.E._Jumper.png/100px-Item_icon_B.A.S.E._Jumper.png",
+		"killIcon": null,
+		"releaseDate": "June 18, 2014 Patch(Love & War Update)",
+		"usedBy": ["Soldier", "Demoman"],
+		"slot": ["Primary", "Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Parachute",
+				"variant": "level"
+			},
+			{
+				"text": "Press 'JUMP' key in the air to deploy.\nDeployed Parachutes slow your descent.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Panic Attack",
+		"link": "/wiki/Panic_Attack",
+		"image": "/w/images/thumb/b/be/Item_icon_Panic_Attack.png/100px-Item_icon_Panic_Attack.png",
+		"killIcon": "/w/images/c/c5/Killicon_panic_attack.png",
+		"releaseDate": "December 22, 2014 Patch(Smissmas 2014)",
+		"usedBy": ["Engineer", "Soldier", "Pyro", "Heavy"],
+		"slot": ["Primary", "Secondary"],
+		"ammoLoaded": "6",
+		"ammoCarried": "32",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Strange", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 - 99 Shotgun",
+				"variant": "level"
+			},
+			{
+				"text": "+50% bullets per shot",
+				"variant": "positive"
+			},
+			{
+				"text": "This weapon deploys 50% faster",
+				"variant": "positive"
+			},
+			{
+				"text": "Fires a wide, fixed shot pattern",
+				"variant": "positive"
+			},
+			{
+				"text": "-20% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "Successive shots become less accurate",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Shovel",
+		"link": "/wiki/Shovel",
+		"image": "/w/images/thumb/7/73/Item_icon_Shovel.png/100px-Item_icon_Shovel.png",
+		"killIcon": "/w/images/6/6e/Killicon_shovel.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Soldier"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Normal", "Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "Level 1 Shovel",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Equalizer",
+		"link": "/wiki/Equalizer",
+		"image": "/w/images/thumb/b/ba/Item_icon_Equalizer.png/100px-Item_icon_Equalizer.png",
+		"killIcon": "/w/images/a/a5/Killicon_equalizer.png",
+		"releaseDate": "December 17, 2009 Patch(WAR! Update)",
+		"usedBy": ["Soldier"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Pickaxe",
+				"variant": "level"
+			},
+			{
+				"text": " When weapon is active: ",
+				"variant": "neutral"
+			},
+			{
+				"text": "Damage increases as the user becomes injured",
+				"variant": "positive"
+			},
+			{
+				"text": "-90% less healing from Medic sources",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Pain Train",
+		"link": "/wiki/Pain_Train",
+		"image": "/w/images/thumb/4/4b/Item_icon_Pain_Train.png/100px-Item_icon_Pain_Train.png",
+		"killIcon": "/w/images/7/79/Killicon_pain_train.png",
+		"releaseDate": "March 18, 2010 Patch(First Community Contribution Update)",
+		"usedBy": ["Soldier", "Demoman"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Makeshift Club",
+				"variant": "level"
+			},
+			{
+				"text": "+1 capture rate on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "10% bullet damage vulnerability on wearer",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Half-Zatoichi",
+		"link": "/wiki/Half-Zatoichi",
+		"image": "/w/images/thumb/a/a9/Item_icon_Half-Zatoichi.png/100px-Item_icon_Half-Zatoichi.png",
+		"killIcon": "/w/images/9/93/Killicon_half-zatoichi.png",
+		"releaseDate": "March 10, 2011 Patch(Shogun Pack)",
+		"usedBy": ["Soldier", "Demoman"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Genuine", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Katana",
+				"variant": "level"
+			},
+			{
+				"text": " This Weapon has a large melee range and\ndeploys and holsters slower ",
+				"variant": "neutral"
+			},
+			{
+				"text": "Gain 50% of base health on kill",
+				"variant": "positive"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "Honorbound: Once drawn sheathing deals 50 damage to yourself unless it kills",
+				"variant": "negative"
+			},
+			{
+				"text": "Soldiers and Demos\nCan duel with katanas\nFor a one-hit kill",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Disciplinary Action",
+		"link": "/wiki/Disciplinary_Action",
+		"image": "/w/images/thumb/c/cf/Item_icon_Disciplinary_Action.png/100px-Item_icon_Disciplinary_Action.png",
+		"killIcon": "/w/images/1/12/Killicon_disciplinary_action.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Soldier"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 10 Riding Crop",
+				"variant": "level"
+			},
+			{
+				"text": "On Hit Teammate: Boosts both players' speed for several seconds",
+				"variant": "positive"
+			},
+			{
+				"text": "-25% damage penalty",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Market Gardener",
+		"link": "/wiki/Market_Gardener",
+		"image": "/w/images/thumb/a/ac/Item_icon_Market_Gardener.png/100px-Item_icon_Market_Gardener.png",
+		"killIcon": "/w/images/0/00/Killicon_market_gardener.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Soldier"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Shovel",
+				"variant": "level"
+			},
+			{
+				"text": "Deals crits while the wielder is rocket jumping",
+				"variant": "positive"
+			},
+			{
+				"text": "20% slower firing speed",
+				"variant": "negative"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Escape Plan",
+		"link": "/wiki/Escape_Plan",
+		"image": "/w/images/thumb/0/0c/Item_icon_Escape_Plan.png/100px-Item_icon_Escape_Plan.png",
+		"killIcon": "/w/images/d/de/Killicon_escape_plan.png",
+		"releaseDate": "June 27, 2012 Patch(Pyromania Update)",
+		"usedBy": ["Soldier"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Pickaxe",
+				"variant": "level"
+			},
+			{
+				"text": " When weapon is active: ",
+				"variant": "neutral"
+			},
+			{
+				"text": "Move speed increases as the user becomes injured",
+				"variant": "positive"
+			},
+			{
+				"text": "You are Marked-For-Death while active, and for short period after switching weapons",
+				"variant": "negative"
+			},
+			{
+				"text": "-90% less healing from Medic sources",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Flame Thrower",
+		"link": "/wiki/Flame_Thrower",
+		"image": "/w/images/thumb/e/ec/Item_icon_Flame_Thrower.png/100px-Item_icon_Flame_Thrower.png",
+		"killIcon": "/w/images/e/eb/Killicon_flame_thrower.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Pyro"],
+		"slot": ["Primary"],
+		"ammoLoaded": "200",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Normal", "Unique", "Strange", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 Flame Thrower",
+				"variant": "level"
+			},
+			{
+				"text": "Extinguishing teammates restores 20 health",
+				"variant": "positive"
+			},
+			{
+				"text": "Afterburn reduces Medi Gun healing and resist shield effects.\nAlt-Fire: Release a blast of air that pushes enemies and projectiles and extinguishes teammates that are on fire.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Rainblower",
+		"link": "/wiki/Rainblower",
+		"image": "/w/images/thumb/3/3c/Item_icon_Rainblower.png/100px-Item_icon_Rainblower.png",
+		"killIcon": "/w/images/f/f6/Killicon_rainblower.png",
+		"releaseDate": "June 27, 2012 Patch(Pyromania Update)",
+		"usedBy": ["Pyro"],
+		"slot": ["Primary"],
+		"ammoLoaded": "200",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Flame Thrower",
+				"variant": "level"
+			},
+			{
+				"text": "On Equip: Visit Pyroland",
+				"variant": "positive"
+			},
+			{
+				"text": "Only visible in Pyroland",
+				"variant": "negative"
+			},
+			{
+				"text": "Your friends (enemies) will squeal with delight (be consumed with fire) when you cover them in sparkly rainbows (all-consuming fire). (Equips Pyrovision.)",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Nostromo Napalmer",
+		"link": "/wiki/Nostromo_Napalmer",
+		"image": "/w/images/thumb/d/d3/Item_icon_Nostromo_Napalmer.png/100px-Item_icon_Nostromo_Napalmer.png",
+		"killIcon": "/w/images/c/c4/Killicon_nostromo_napalmer.png",
+		"releaseDate": "September 17, 2014 Patch",
+		"usedBy": ["Pyro"],
+		"slot": ["Primary"],
+		"ammoLoaded": "200",
+		"ammoCarried": "N/A",
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Genuine"],
+		"attributes": [
+			{
+				"text": "Level 10 Flame Thrower",
+				"variant": "level"
+			},
+			{
+				"text": "Extinguishing teammates restores 20 health",
+				"variant": "positive"
+			}
+		]
+	},
+	{
+		"name": "Backburner",
+		"link": "/wiki/Backburner",
+		"image": "/w/images/thumb/5/5d/Item_icon_Backburner.png/100px-Item_icon_Backburner.png",
+		"killIcon": "/w/images/3/3a/Killicon_backburner.png",
+		"releaseDate": "June 19, 2008 Patch(Pyro Update)",
+		"usedBy": ["Pyro"],
+		"slot": ["Primary"],
+		"ammoLoaded": "200",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Flame Thrower",
+				"variant": "level"
+			},
+			{
+				"text": "100% critical hits from behind",
+				"variant": "positive"
+			},
+			{
+				"text": "+150% airblast cost",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Degreaser",
+		"link": "/wiki/Degreaser",
+		"image": "/w/images/thumb/9/94/Item_icon_Degreaser.png/100px-Item_icon_Degreaser.png",
+		"killIcon": "/w/images/0/0f/Killicon_degreaser.png",
+		"releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
+		"usedBy": ["Pyro"],
+		"slot": ["Primary"],
+		"ammoLoaded": "200",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 10 Flame Thrower",
+				"variant": "level"
+			},
+			{
+				"text": "This weapon holsters 30% faster",
+				"variant": "positive"
+			},
+			{
+				"text": "This weapon deploys 60% faster",
+				"variant": "positive"
+			},
+			{
+				"text": "Extinguishing teammates restores 20 health",
+				"variant": "positive"
+			},
+			{
+				"text": "-66% afterburn damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "+25% airblast cost",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Phlogistinator",
+		"link": "/wiki/Phlogistinator",
+		"image": "/w/images/thumb/2/22/Item_icon_Phlogistinator.png/100px-Item_icon_Phlogistinator.png",
+		"killIcon": "/w/images/6/66/Killicon_phlogistinator.png",
+		"releaseDate": "December 15, 2011 Patch(Australian Christmas 2011)",
+		"usedBy": ["Pyro"],
+		"slot": ["Primary"],
+		"ammoLoaded": "200",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Flame Thrower",
+				"variant": "level"
+			},
+			{
+				"text": "Build 'Mmmph' by dealing damage.\nAlt-Fire on full 'Mmmph': Taunt to gain crit for several seconds.\nInvulnerable while 'Mmmph' taunting.",
+				"variant": "positive"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "No airblast",
+				"variant": "negative"
+			},
+			{
+				"text": "Being a revolutionary appliance capable of awakening the fire element phlogiston that exists in all combustible creatures, which is to say, all of them.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Contract",
+		"link": "/wiki/Dragon%27s_Fury",
+		"image": "/w/images/thumb/1/1f/Item_icon_Dragon%27s_Fury.png/100px-Item_icon_Dragon%27s_Fury.png",
+		"killIcon": "/w/images/2/20/Killicon_dragon%27s_fury.png",
+		"releaseDate": "October 20, 2017 Patch(Jungle Inferno Update)",
+		"usedBy": ["Pyro"],
+		"slot": ["Primary"],
+		"ammoLoaded": "40",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Flame Launcher",
+				"variant": "level"
+			},
+			{
+				"text": " Uses a shared pressure tank for Primary Fire and Alt-Fire.\n\nPrimary Fire: Launches a fast-moving projectile that briefly ignites enemies\n\nAlt-Fire: Release a blast of air that pushes enemies and projectiles, and extinguishes teammates that are on fire. ",
+				"variant": "neutral"
+			},
+			{
+				"text": "Extinguishing teammates restores 20 health",
+				"variant": "positive"
+			},
+			{
+				"text": "Deals 300% damage to burning players\n+50% re-pressurization rate on hit",
+				"variant": "positive"
+			},
+			{
+				"text": "-50% repressurization rate on Alt-Fire",
+				"variant": "negative"
+			},
+			{
+				"text": "This powerful, single-shot flamethrower rewards consecutive hits with faster reloads and bonus damage.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Flare Gun",
+		"link": "/wiki/Flare_Gun",
+		"image": "/w/images/thumb/7/7b/Item_icon_Flare_Gun.png/100px-Item_icon_Flare_Gun.png",
+		"killIcon": "/w/images/d/d4/Killicon_flare_gun.png",
+		"releaseDate": "June 19, 2008 Patch(Pyro Update)",
+		"usedBy": ["Pyro"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "16",
+		"ammoCarried": null,
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Flare Gun",
+				"variant": "level"
+			},
+			{
+				"text": "100% critical hit vs burning players",
+				"variant": "positive"
+			},
+			{
+				"text": "This weapon will reload when not active",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Detonator",
+		"link": "/wiki/Detonator",
+		"image": "/w/images/thumb/5/53/Item_icon_Detonator.png/100px-Item_icon_Detonator.png",
+		"killIcon": "/w/images/9/9e/Killicon_detonator.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Pyro"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "16",
+		"ammoCarried": null,
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 10 Flare Gun",
+				"variant": "level"
+			},
+			{
+				"text": "100% mini-crits vs burning players",
+				"variant": "positive"
+			},
+			{
+				"text": "-25% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "+50% damage to self",
+				"variant": "negative"
+			},
+			{
+				"text": "Alt-Fire: Detonate flare.\nThis weapon will reload automatically when not active.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Manmelter",
+		"link": "/wiki/Manmelter",
+		"image": "/w/images/thumb/9/9d/Item_icon_Manmelter.png/100px-Item_icon_Manmelter.png",
+		"killIcon": "/w/images/a/ad/Killicon_manmelter.png",
+		"releaseDate": "December 15, 2011 Patch(Australian Christmas 2011)",
+		"usedBy": ["Pyro"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "Unlimited",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 30 Indivisible Particle Smasher",
+				"variant": "level"
+			},
+			{
+				"text": "+50% projectile speed",
+				"variant": "positive"
+			},
+			{
+				"text": "Does not require ammo",
+				"variant": "positive"
+			},
+			{
+				"text": "Alt-Fire: Extinguish teammates to gain guaranteed critical hits",
+				"variant": "positive"
+			},
+			{
+				"text": "Extinguishing teammates restores 20 health",
+				"variant": "positive"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "This weapon will reload automatically when not active.\n\nBeing a device that flouts conventional scientific consensus that the molecules composing the human body must be arranged \"just so\", and not, for example, across a square-mile radius.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Scorch Shot",
+		"link": "/wiki/Scorch_Shot",
+		"image": "/w/images/thumb/b/be/Item_icon_Scorch_Shot.png/100px-Item_icon_Scorch_Shot.png",
+		"killIcon": "/w/images/2/20/Killicon_scorch_shot.png",
+		"releaseDate": "June 27, 2012 Patch(Pyromania Update)",
+		"usedBy": ["Pyro"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "16",
+		"ammoCarried": null,
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 10 Flare Gun",
+				"variant": "level"
+			},
+			{
+				"text": "100% mini-crits vs burning players",
+				"variant": "positive"
+			},
+			{
+				"text": "Flare knocks back target on hit\nand explodes when it hits the ground.\nIncreased knock back on burning players",
+				"variant": "positive"
+			},
+			{
+				"text": "-35% self damage force",
+				"variant": "negative"
+			},
+			{
+				"text": "-35% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "This weapon will reload automatically when not active.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Fire Axe",
+		"link": "/wiki/Fire_Axe",
+		"image": "/w/images/thumb/9/9f/Item_icon_Fire_Axe.png/100px-Item_icon_Fire_Axe.png",
+		"killIcon": "/w/images/d/da/Killicon_fire_axe.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Pyro"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Normal", "Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "Level 1 Fire Axe",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Lollichop",
+		"link": "/wiki/Lollichop",
+		"image": "/w/images/thumb/6/65/Item_icon_Lollichop.png/100px-Item_icon_Lollichop.png",
+		"killIcon": "/w/images/4/44/Killicon_lollichop.png",
+		"releaseDate": "June 27, 2012 Patch(Pyromania Update)",
+		"usedBy": ["Pyro"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Fire Axe",
+				"variant": "level"
+			},
+			{
+				"text": "On Equip: Visit Pyroland",
+				"variant": "positive"
+			},
+			{
+				"text": "Only visible in Pyroland",
+				"variant": "negative"
+			},
+			{
+				"text": "Fill (split) your buddies' tummies (skulls) with delicious candy (cold steel) with this oversized sugary treat. (Equips Pyrovision.)",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Axtinguisher",
+		"link": "/wiki/Axtinguisher",
+		"image": "/w/images/thumb/c/c9/Item_icon_Axtinguisher.png/100px-Item_icon_Axtinguisher.png",
+		"killIcon": "/w/images/5/59/Killicon_axtinguisher.png",
+		"releaseDate": "June 19, 2008 Patch(Pyro Update)",
+		"usedBy": ["Pyro"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Fire Axe",
+				"variant": "level"
+			},
+			{
+				"text": "Mini-crits burning targets and extinguishes them.\nDamage increases based on remaining duration of afterburn\nKilling blows on burning players grant a speed boost.",
+				"variant": "positive"
+			},
+			{
+				"text": "-33% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "This weapon holsters 35% slower",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Postal Pummeler",
+		"link": "/wiki/Postal_Pummeler",
+		"image": "/w/images/thumb/2/2d/Item_icon_Postal_Pummeler.png/100px-Item_icon_Postal_Pummeler.png",
+		"killIcon": "/w/images/a/a3/Killicon_postal_pummeler.png",
+		"releaseDate": "July 1, 2011 Patch(Summer Camp Sale)",
+		"usedBy": ["Pyro"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Mailbox",
+				"variant": "level"
+			},
+			{
+				"text": "Mini-crits burning targets and extinguishes them.\nDamage increases based on remaining duration of afterburn\nKilling blows on burning players grant a speed boost.",
+				"variant": "positive"
+			},
+			{
+				"text": "-33% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "This weapon holsters 35% slower",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Homewrecker",
+		"link": "/wiki/Homewrecker",
+		"image": "/w/images/thumb/4/4a/Item_icon_Homewrecker.png/100px-Item_icon_Homewrecker.png",
+		"killIcon": "/w/images/7/72/Killicon_homewrecker.png",
+		"releaseDate": "March 18, 2010 Patch(First Community Contribution Update)",
+		"usedBy": ["Pyro"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Sledgehammer",
+				"variant": "level"
+			},
+			{
+				"text": "+100% damage vs buildings",
+				"variant": "positive"
+			},
+			{
+				"text": "Damage removes Sappers",
+				"variant": "positive"
+			},
+			{
+				"text": "-25% damage vs players",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Maul",
+		"link": "/wiki/Maul",
+		"image": "/w/images/thumb/2/2e/Item_icon_Maul.png/100px-Item_icon_Maul.png",
+		"killIcon": "/w/images/9/91/Killicon_maul.png",
+		"releaseDate": "June 3, 2011 Patch",
+		"usedBy": ["Pyro"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Genuine"],
+		"attributes": [
+			{
+				"text": "Level 5 Sledgehammer",
+				"variant": "level"
+			},
+			{
+				"text": "+100% damage vs buildings",
+				"variant": "positive"
+			},
+			{
+				"text": "Damage removes Sappers",
+				"variant": "positive"
+			},
+			{
+				"text": "-25% damage vs players",
+				"variant": "negative"
+			},
+			{
+				"text": "Packs a devastating punch with a hint of Mars dust.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Powerjack",
+		"link": "/wiki/Powerjack",
+		"image": "/w/images/thumb/c/cf/Item_icon_Powerjack.png/100px-Item_icon_Powerjack.png",
+		"killIcon": "/w/images/5/51/Killicon_powerjack.png",
+		"releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
+		"usedBy": ["Pyro"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 5 Sledgehammer",
+				"variant": "level"
+			},
+			{
+				"text": " When weapon is active: ",
+				"variant": "neutral"
+			},
+			{
+				"text": "+15% faster move speed on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "+25 health restored on kill",
+				"variant": "positive"
+			},
+			{
+				"text": "20% damage vulnerability on wearer",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Back Scratcher",
+		"link": "/wiki/Back_Scratcher",
+		"image": "/w/images/thumb/4/48/Item_icon_Back_Scratcher.png/100px-Item_icon_Back_Scratcher.png",
+		"killIcon": "/w/images/f/ff/Killicon_back_scratcher.png",
+		"releaseDate": "December 17, 2010 Patch(Australian Christmas)",
+		"usedBy": ["Pyro"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 10 Garden Rake",
+				"variant": "level"
+			},
+			{
+				"text": "+25% damage bonus",
+				"variant": "positive"
+			},
+			{
+				"text": "+50% health from packs on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "-75% health from healers on wearer",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Sharpened Volcano Fragment",
+		"link": "/wiki/Sharpened_Volcano_Fragment",
+		"image": "/w/images/thumb/a/ac/Item_icon_Sharpened_Volcano_Fragment.png/100px-Item_icon_Sharpened_Volcano_Fragment.png",
+		"killIcon": "/w/images/8/80/Killicon_sharpened_volcano_fragment.png",
+		"releaseDate": "February 3, 2011 Patch",
+		"usedBy": ["Pyro"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Genuine", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 RIFT Fire Axe",
+				"variant": "level"
+			},
+			{
+				"text": "On Hit: target is engulfed in flames",
+				"variant": "positive"
+			},
+			{
+				"text": "-20% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "Improves upon Mother Nature's original design for volcanos by increasing portability. Modern science is unable to explain exactly where the lava is coming from.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Third Degree",
+		"link": "/wiki/Third_Degree",
+		"image": "/w/images/thumb/9/91/Item_icon_Third_Degree.png/100px-Item_icon_Third_Degree.png",
+		"killIcon": "/w/images/2/22/Killicon_third_degree.png",
+		"releaseDate": "December 15, 2011 Patch(Australian Christmas 2011)",
+		"usedBy": ["Pyro"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Fire Axe",
+				"variant": "level"
+			},
+			{
+				"text": "All players connected via Medigun beams are hit",
+				"variant": "positive"
+			},
+			{
+				"text": "Being a boon to tree-fellers, backwoodsmen and atom-splitters the world over, this miraculous matter-hewing device burns each individual molecule as it cleaves it.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Neon Annihilator",
+		"link": "/wiki/Neon_Annihilator",
+		"image": "/w/images/thumb/e/e9/Item_icon_Neon_Annihilator.png/100px-Item_icon_Neon_Annihilator.png",
+		"killIcon": "/w/images/5/5b/Killicon_neon_annihilator.png",
+		"releaseDate": "August 2, 2012 Patch(Triad Pack)",
+		"usedBy": ["Pyro"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Genuine", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Sign",
+				"variant": "level"
+			},
+			{
+				"text": "Damage removes Sappers",
+				"variant": "positive"
+			},
+			{
+				"text": "100% critical hit vs wet players",
+				"variant": "positive"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "-20% damage vs players",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Grenade Launcher",
+		"link": "/wiki/Grenade_Launcher",
+		"image": "/w/images/thumb/e/e6/Item_icon_Grenade_Launcher.png/100px-Item_icon_Grenade_Launcher.png",
+		"killIcon": "/w/images/d/db/Killicon_grenade_launcher.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Demoman"],
+		"slot": ["Primary"],
+		"ammoLoaded": "4  / 6",
+		"ammoCarried": "16  / 30",
+		"reloadType": "Single\n  ",
+		"qualities": ["Normal", "Unique", "Strange", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 Grenade Launcher",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Loch-n-Load",
+		"link": "/wiki/Loch-n-Load",
+		"image": "/w/images/thumb/6/62/Item_icon_Loch-n-Load.png/100px-Item_icon_Loch-n-Load.png",
+		"killIcon": "/w/images/6/6a/Killicon_loch-n-load.png",
+		"releaseDate": "December 17, 2010 Patch(Australian Christmas)",
+		"usedBy": ["Demoman"],
+		"slot": ["Primary"],
+		"ammoLoaded": "3",
+		"ammoCarried": "16",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 10 Grenade Launcher",
+				"variant": "level"
+			},
+			{
+				"text": "+20% damage vs buildings",
+				"variant": "positive"
+			},
+			{
+				"text": "+25% projectile speed",
+				"variant": "positive"
+			},
+			{
+				"text": "-25% clip size",
+				"variant": "negative"
+			},
+			{
+				"text": "-25% explosion radius",
+				"variant": "negative"
+			},
+			{
+				"text": "Launched bombs shatter on surfaces",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Ali Baba's Wee Booties",
+		"link": "/wiki/Ali_Baba%27s_Wee_Booties",
+		"image": "/w/images/thumb/a/a4/Item_icon_Ali_Baba%27s_Wee_Booties.png/100px-Item_icon_Ali_Baba%27s_Wee_Booties.png",
+		"killIcon": null,
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Demoman"],
+		"slot": ["Primary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Boots",
+				"variant": "level"
+			},
+			{
+				"text": "+25 max health on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "+200% increase in turning control while charging",
+				"variant": "positive"
+			},
+			{
+				"text": "+10% faster move speed on wearer (shield required)",
+				"variant": "positive"
+			},
+			{
+				"text": "Melee kills refill 25% of your charge meter",
+				"variant": "positive"
+			}
+		]
+	},
+	{
+		"name": "Bootlegger",
+		"link": "/wiki/Bootlegger",
+		"image": "/w/images/thumb/4/4c/Item_icon_Bootlegger.png/100px-Item_icon_Bootlegger.png",
+		"killIcon": null,
+		"releaseDate": "October 13, 2011 Patch(Manniversary Update & Sale)",
+		"usedBy": ["Demoman"],
+		"slot": ["Primary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Boots",
+				"variant": "level"
+			},
+			{
+				"text": "+25 max health on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "+200% increase in turning control while charging",
+				"variant": "positive"
+			},
+			{
+				"text": "+10% faster move speed on wearer (shield required)",
+				"variant": "positive"
+			},
+			{
+				"text": "Melee kills refill 25% of your charge meter",
+				"variant": "positive"
+			},
+			{
+				"text": "Amaze your friends! Impress women! Walk with a limp for life! It's grotesque!",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Loose Cannon",
+		"link": "/wiki/Loose_Cannon",
+		"image": "/w/images/thumb/7/70/Item_icon_Loose_Cannon.png/100px-Item_icon_Loose_Cannon.png",
+		"killIcon": "/w/images/e/e1/Killicon_loose_cannon.png",
+		"releaseDate": "December 20, 2012 Patch(Mecha Update)",
+		"usedBy": ["Demoman"],
+		"slot": ["Primary"],
+		"ammoLoaded": "4",
+		"ammoCarried": "16",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 10 Grenade Launcher",
+				"variant": "level"
+			},
+			{
+				"text": " Cannonballs have a fuse time of 1 second; fuses can be primed to explode earlier by holding down the fire key ",
+				"variant": "neutral"
+			},
+			{
+				"text": "+20% projectile speed",
+				"variant": "positive"
+			},
+			{
+				"text": "Cannonballs push players back on impact",
+				"variant": "positive"
+			},
+			{
+				"text": "Cannonballs do not explode on impact",
+				"variant": "negative"
+			},
+			{
+				"text": "Double Donk! Bomb explosions after a cannon ball impact will deal mini-crits to impact victims",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Iron Bomber",
+		"link": "/wiki/Iron_Bomber",
+		"image": "/w/images/thumb/c/cd/Item_icon_Iron_Bomber.png/100px-Item_icon_Iron_Bomber.png",
+		"killIcon": "/w/images/3/34/Killicon_iron_bomber.png",
+		"releaseDate": "December 22, 2014 Patch(Smissmas 2014)",
+		"usedBy": ["Demoman"],
+		"slot": ["Primary"],
+		"ammoLoaded": "4",
+		"ammoCarried": "16",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Strange", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 - 99 Grenade Launcher",
+				"variant": "level"
+			},
+			{
+				"text": "Grenades have very little bounce and roll",
+				"variant": "positive"
+			},
+			{
+				"text": "-30% fuse time on grenades",
+				"variant": "positive"
+			},
+			{
+				"text": "-15% explosion radius",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Stickybomb Launcher",
+		"link": "/wiki/Stickybomb_Launcher",
+		"image": "/w/images/thumb/7/7c/Item_icon_Stickybomb_Launcher.png/100px-Item_icon_Stickybomb_Launcher.png",
+		"killIcon": "/w/images/0/08/Killicon_stickybomb_launcher.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Demoman"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "8",
+		"ammoCarried": "24 / 40",
+		"reloadType": "Single\n  ",
+		"qualities": ["Normal", "Unique", "Strange", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 Stickybomb Launcher",
+				"variant": "level"
+			},
+			{
+				"text": "Alt-Fire: Detonate all stickybombs",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Scottish Resistance",
+		"link": "/wiki/Scottish_Resistance",
+		"image": "/w/images/thumb/2/2c/Item_icon_Scottish_Resistance.png/100px-Item_icon_Scottish_Resistance.png",
+		"killIcon": "/w/images/1/1b/Killicon_scottish_resistance.png",
+		"releaseDate": "December 17, 2009 Patch(WAR! Update)",
+		"usedBy": ["Demoman"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "8",
+		"ammoCarried": "36",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Stickybomb Launcher",
+				"variant": "level"
+			},
+			{
+				"text": "+25% faster firing speed",
+				"variant": "positive"
+			},
+			{
+				"text": "+50% max secondary ammo on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "+6 max pipebombs out",
+				"variant": "positive"
+			},
+			{
+				"text": "Detonates stickybombs near the crosshair and directly under your feet",
+				"variant": "positive"
+			},
+			{
+				"text": "Able to destroy enemy stickybombs",
+				"variant": "positive"
+			},
+			{
+				"text": "0.8 sec slower bomb arm time",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Chargin' Targe",
+		"link": "/wiki/Chargin%27_Targe",
+		"image": "/w/images/thumb/7/7a/Item_icon_Chargin%27_Targe.png/100px-Item_icon_Chargin%27_Targe.png",
+		"killIcon": "/w/images/3/38/Killicon_chargin%27_targe.png",
+		"releaseDate": "December 17, 2009 Patch(WAR! Update)",
+		"usedBy": ["Demoman"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "Recharge\n  ",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 - 99 Shield",
+				"variant": "level"
+			},
+			{
+				"text": "+50% fire damage resistance on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "+30% explosive damage resistance on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "Alt-Fire: Charge toward your enemies and remove debuffs.\nGain a critical melee strike after impacting an enemy at distance.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Sticky Jumper",
+		"link": "/wiki/Sticky_Jumper",
+		"image": "/w/images/thumb/5/56/Item_icon_Sticky_Jumper.png/100px-Item_icon_Sticky_Jumper.png",
+		"killIcon": null,
+		"releaseDate": "October 27, 2010 Patch(Scream Fortress Update)",
+		"usedBy": ["Demoman"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "8",
+		"ammoCarried": "72",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 Stickybomb Launcher",
+				"variant": "level"
+			},
+			{
+				"text": "+200% max secondary ammo on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "No self inflicted blast damage taken",
+				"variant": "positive"
+			},
+			{
+				"text": "-100% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "-6 max pipebombs out",
+				"variant": "negative"
+			},
+			{
+				"text": "Wearer cannot carry the intelligence briefcase or PASS Time JACK",
+				"variant": "negative"
+			},
+			{
+				"text": "A special no-damage stickybomb launcher for learning stickybomb jump tricks and patterns.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Splendid Screen",
+		"link": "/wiki/Splendid_Screen",
+		"image": "/w/images/thumb/c/c3/Item_icon_Splendid_Screen.png/100px-Item_icon_Splendid_Screen.png",
+		"killIcon": "/w/images/f/fb/Killicon_splendid_screen.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Demoman"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "Recharge\n  ",
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Shield",
+				"variant": "level"
+			},
+			{
+				"text": "+20% fire damage resistance on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "+20% explosive damage resistance on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "+70% increase in charge impact damage",
+				"variant": "positive"
+			},
+			{
+				"text": "+50% increase in charge recharge rate",
+				"variant": "positive"
+			},
+			{
+				"text": "Alt-Fire: Charge toward your enemies and remove debuffs.\nGain a critical melee strike after impacting an enemy.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Tide Turner",
+		"link": "/wiki/Tide_Turner",
+		"image": "/w/images/thumb/c/cd/Item_icon_Tide_Turner.png/100px-Item_icon_Tide_Turner.png",
+		"killIcon": "/w/images/f/fd/Killicon_tide_turner.png",
+		"releaseDate": "June 18, 2014 Patch(Love & War Update)",
+		"usedBy": ["Demoman"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "Recharge\n  ",
+		"qualities": ["Unique", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Shield",
+				"variant": "level"
+			},
+			{
+				"text": "+15% fire damage resistance on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "+15% explosive damage resistance on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "Full turning control while charging",
+				"variant": "positive"
+			},
+			{
+				"text": "Melee kills refill 75% of your charge meter",
+				"variant": "positive"
+			},
+			{
+				"text": "Taking damage while shield charging reduces remaining charging time",
+				"variant": "negative"
+			},
+			{
+				"text": "Alt-Fire: Charge toward your enemies and remove debuffs.\nGain a mini-crit melee strike after impacting an enemy at distance.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Quickiebomb Launcher",
+		"link": "/wiki/Quickiebomb_Launcher",
+		"image": "/w/images/thumb/f/f9/Item_icon_Quickiebomb_Launcher.png/100px-Item_icon_Quickiebomb_Launcher.png",
+		"killIcon": "/w/images/6/6a/Killicon_quickiebomb_launcher.png",
+		"releaseDate": "December 22, 2014 Patch(Smissmas 2014)",
+		"usedBy": ["Demoman"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "4",
+		"ammoCarried": "24",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "Level 1 - 99 Stickybomb Launcher",
+				"variant": "level"
+			},
+			{
+				"text": "Able to destroy enemy stickybombs",
+				"variant": "positive"
+			},
+			{
+				"text": "-0.2 sec faster bomb arm time",
+				"variant": "positive"
+			},
+			{
+				"text": "Max charge time decreased by 70%",
+				"variant": "positive"
+			},
+			{
+				"text": "Up to +35% damage based on charge",
+				"variant": "positive"
+			},
+			{
+				"text": "-15% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "-50% clip size",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Bottle",
+		"link": "/wiki/Bottle",
+		"image": "/w/images/thumb/b/b2/Item_icon_Bottle.png/100px-Item_icon_Bottle.png",
+		"killIcon": "/w/images/6/68/Killicon_bottle.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Demoman"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Normal", "Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "Level 1 Bottle",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Scottish Handshake",
+		"link": "/wiki/Scottish_Handshake",
+		"image": "/w/images/thumb/1/1a/Item_icon_Scottish_Handshake.png/100px-Item_icon_Scottish_Handshake.png",
+		"killIcon": "/w/images/6/6e/Killicon_scottish_handshake.png",
+		"releaseDate": "October 13, 2011 Patch(Manniversary Update & Sale)",
+		"usedBy": ["Demoman"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Bottle",
+				"variant": "level"
+			},
+			{
+				"text": "Your enemies will think you're making peace, right up until the terrifying moment that their hand is very seriously cut! Here's the trick: It's a broken bottle!",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Eyelander",
+		"link": "/wiki/Eyelander",
+		"image": "/w/images/thumb/9/94/Item_icon_Eyelander.png/100px-Item_icon_Eyelander.png",
+		"killIcon": "/w/images/5/53/Killicon_eyelander.png",
+		"releaseDate": "December 17, 2009 Patch(WAR! Update)",
+		"usedBy": ["Demoman"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Sword",
+				"variant": "level"
+			},
+			{
+				"text": " This Weapon has a large melee range and\ndeploys and holsters slower ",
+				"variant": "neutral"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "-25 max health on wearer",
+				"variant": "negative"
+			},
+			{
+				"text": "Gives increased speed and health\nwith every head you take.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Horseless Headless Horsemann's Headtaker",
+		"link": "/wiki/Horseless_Headless_Horsemann%27s_Headtaker",
+		"image": "/w/images/thumb/1/1f/Item_icon_Horseless_Headless_Horsemann%27s_Headtaker.png/100px-Item_icon_Horseless_Headless_Horsemann%27s_Headtaker.png",
+		"killIcon": "/w/images/f/fa/Killicon_horseless_headless_horsemann%27s_headtaker.png",
+		"releaseDate": "October 27, 2010 Patch(Scream Fortress Update)",
+		"usedBy": ["Demoman"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Strange", "Unusual"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Axe",
+				"variant": "level"
+			},
+			{
+				"text": " This Weapon has a large melee range and\ndeploys and holsters slower ",
+				"variant": "neutral"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "-25 max health on wearer",
+				"variant": "negative"
+			},
+			{
+				"text": "Cursed by dark spirits similar to\nthose that dwell within the Eyelander.",
+				"variant": "neutral"
+			},
+			{
+				"text": "( Not Tradable or Marketable )",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Nessie's Nine Iron",
+		"link": "/wiki/Nessie%27s_Nine_Iron",
+		"image": "/w/images/thumb/5/5a/Item_icon_Nessie%27s_Nine_Iron.png/100px-Item_icon_Nessie%27s_Nine_Iron.png",
+		"killIcon": "/w/images/3/34/Killicon_nessie%27s_nine_iron.png",
+		"releaseDate": "July 1, 2011 Patch(Summer Camp Sale)",
+		"usedBy": ["Demoman"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Golf Club",
+				"variant": "level"
+			},
+			{
+				"text": " This Weapon has a large melee range and\ndeploys and holsters slower ",
+				"variant": "neutral"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "-25 max health on wearer",
+				"variant": "negative"
+			},
+			{
+				"text": "Gives increased speed and health\nwith every head you take.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Scotsman's Skullcutter",
+		"link": "/wiki/Scotsman%27s_Skullcutter",
+		"image": "/w/images/thumb/c/c6/Item_icon_Scotsman%27s_Skullcutter.png/100px-Item_icon_Scotsman%27s_Skullcutter.png",
+		"killIcon": "/w/images/2/20/Killicon_scotsman%27s_skullcutter.png",
+		"releaseDate": "May 20, 2010 Patch(Second Community Contribution Update)",
+		"usedBy": ["Demoman"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 5 Axe",
+				"variant": "level"
+			},
+			{
+				"text": " This Weapon has a large melee range and\ndeploys and holsters slower ",
+				"variant": "neutral"
+			},
+			{
+				"text": " When weapon is active: ",
+				"variant": "neutral"
+			},
+			{
+				"text": "+20% damage bonus",
+				"variant": "positive"
+			},
+			{
+				"text": "15% slower move speed on wearer",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Ullapool Caber",
+		"link": "/wiki/Ullapool_Caber",
+		"image": "/w/images/thumb/a/a5/Item_icon_Ullapool_Caber.png/100px-Item_icon_Ullapool_Caber.png",
+		"killIcon": "/w/images/7/74/Killicon_ullapool_caber.png",
+		"releaseDate": "December 17, 2010 Patch(Australian Christmas)",
+		"usedBy": ["Demoman"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Stick Bomb",
+				"variant": "level"
+			},
+			{
+				"text": "20% slower firing speed",
+				"variant": "negative"
+			},
+			{
+				"text": "This weapon deploys 100% slower",
+				"variant": "negative"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "High-yield Scottish face removal.\nA sober person would throw it...\n\nThe first hit will cause an explosion",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Claidheamh M\u00f2r",
+		"link": "/wiki/Claidheamh_M%C3%B2r",
+		"image": "/w/images/thumb/0/0f/Item_icon_Claidheamh_M%C3%B2r.png/100px-Item_icon_Claidheamh_M%C3%B2r.png",
+		"killIcon": "/w/images/9/9e/Killicon_claidheamh_m%C3%B2r.png",
+		"releaseDate": "December 17, 2010 Patch(Australian Christmas)",
+		"usedBy": ["Demoman"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 5 Sword",
+				"variant": "level"
+			},
+			{
+				"text": " When weapon is active: ",
+				"variant": "neutral"
+			},
+			{
+				"text": " This Weapon has a large melee range and\ndeploys and holsters slower ",
+				"variant": "neutral"
+			},
+			{
+				"text": "0.5 sec increase in charge duration",
+				"variant": "positive"
+			},
+			{
+				"text": "Melee kills refill 25% of your charge meter",
+				"variant": "positive"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "15% damage vulnerability on wearer",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Persian Persuader",
+		"link": "/wiki/Persian_Persuader",
+		"image": "/w/images/thumb/9/98/Item_icon_Persian_Persuader.png/100px-Item_icon_Persian_Persuader.png",
+		"killIcon": "/w/images/c/c5/Killicon_persian_persuader.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Demoman"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 10 Sword",
+				"variant": "level"
+			},
+			{
+				"text": " This Weapon has a large melee range and\ndeploys and holsters slower ",
+				"variant": "neutral"
+			},
+			{
+				"text": "Melee hits refill 20% of your charge meter",
+				"variant": "positive"
+			},
+			{
+				"text": "Ammo boxes collected also refill your charge meter",
+				"variant": "positive"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "-80% max primary ammo on wearer",
+				"variant": "negative"
+			},
+			{
+				"text": "-80% max secondary ammo on wearer",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Minigun",
+		"link": "/wiki/Minigun",
+		"image": "/w/images/thumb/a/a7/Item_icon_Minigun.png/100px-Item_icon_Minigun.png",
+		"killIcon": "/w/images/e/ee/Killicon_minigun.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Heavy"],
+		"slot": ["Primary"],
+		"ammoLoaded": "200",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Normal", "Unique", "Strange", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 Minigun",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Iron Curtain",
+		"link": "/wiki/Iron_Curtain",
+		"image": "/w/images/thumb/d/da/Item_icon_Iron_Curtain.png/100px-Item_icon_Iron_Curtain.png",
+		"killIcon": "/w/images/3/3d/Killicon_iron_curtain.png",
+		"releaseDate": "November 19, 2010 Patch",
+		"usedBy": ["Heavy"],
+		"slot": ["Primary"],
+		"ammoLoaded": "200",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique"],
+		"attributes": [
+			{
+				"text": "Level 5 Minigun",
+				"variant": "level"
+			},
+			{
+				"text": "( Achievement Item: Not Tradable or Marketable )",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Natascha",
+		"link": "/wiki/Natascha",
+		"image": "/w/images/thumb/c/cc/Item_icon_Natascha.png/100px-Item_icon_Natascha.png",
+		"killIcon": "/w/images/f/f1/Killicon_natascha.png",
+		"releaseDate": "August 19, 2008 Patch(Heavy Update)",
+		"usedBy": ["Heavy"],
+		"slot": ["Primary"],
+		"ammoLoaded": "200",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Minigun",
+				"variant": "level"
+			},
+			{
+				"text": "On Hit: 100% chance to slow target",
+				"variant": "positive"
+			},
+			{
+				"text": "-20% damage resistance when below 50% health and spun up",
+				"variant": "positive"
+			},
+			{
+				"text": "-25% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "30% slower spin up time",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Brass Beast",
+		"link": "/wiki/Brass_Beast",
+		"image": "/w/images/thumb/6/64/Item_icon_Brass_Beast.png/100px-Item_icon_Brass_Beast.png",
+		"killIcon": "/w/images/0/03/Killicon_brass_beast.png",
+		"releaseDate": "December 17, 2010 Patch(Australian Christmas)",
+		"usedBy": ["Heavy"],
+		"slot": ["Primary"],
+		"ammoLoaded": "200",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 5 Minigun",
+				"variant": "level"
+			},
+			{
+				"text": "+20% damage bonus",
+				"variant": "positive"
+			},
+			{
+				"text": "-20% damage resistance when below 50% health and spun up",
+				"variant": "positive"
+			},
+			{
+				"text": "50% slower spin up time",
+				"variant": "negative"
+			},
+			{
+				"text": "-60% slower move speed while deployed",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Tomislav",
+		"link": "/wiki/Tomislav",
+		"image": "/w/images/thumb/3/3e/Item_icon_Tomislav.png/100px-Item_icon_Tomislav.png",
+		"killIcon": "/w/images/2/27/Killicon_tomislav.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Heavy"],
+		"slot": ["Primary"],
+		"ammoLoaded": "200",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 5 Minigun",
+				"variant": "level"
+			},
+			{
+				"text": "20% faster spin up time",
+				"variant": "positive"
+			},
+			{
+				"text": "20% more accurate",
+				"variant": "positive"
+			},
+			{
+				"text": "Silent Killer: No barrel spin sound",
+				"variant": "positive"
+			},
+			{
+				"text": "20% slower firing speed",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Huo-Long Heater",
+		"link": "/wiki/Huo-Long_Heater",
+		"image": "/w/images/thumb/8/81/Item_icon_Huo-Long_Heater.png/100px-Item_icon_Huo-Long_Heater.png",
+		"killIcon": "/w/images/0/09/Killicon_huo-long_heater.png",
+		"releaseDate": "August 2, 2012 Patch(Triad Pack)",
+		"usedBy": ["Heavy"],
+		"slot": ["Primary"],
+		"ammoLoaded": "200",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Genuine", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Minigun",
+				"variant": "level"
+			},
+			{
+				"text": "Creates a ring of flames while spun up",
+				"variant": "positive"
+			},
+			{
+				"text": "25% damage bonus vs burning players",
+				"variant": "positive"
+			},
+			{
+				"text": "-10% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "Consumes an additional 4 ammo per second while spun up",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Family Business",
+		"link": "/wiki/Family_Business",
+		"image": "/w/images/thumb/c/cd/Item_icon_Family_Business.png/100px-Item_icon_Family_Business.png",
+		"killIcon": "/w/images/3/38/Killicon_family_business.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Heavy"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "8",
+		"ammoCarried": "32",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 10 Shotgun",
+				"variant": "level"
+			},
+			{
+				"text": "+33% clip size",
+				"variant": "positive"
+			},
+			{
+				"text": "+15% faster firing speed",
+				"variant": "positive"
+			},
+			{
+				"text": "-15% damage penalty",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Sandvich",
+		"link": "/wiki/Sandvich",
+		"image": "/w/images/thumb/5/5e/Item_icon_Sandvich.png/100px-Item_icon_Sandvich.png",
+		"killIcon": null,
+		"releaseDate": "August 19, 2008 Patch(Heavy Update)",
+		"usedBy": ["Heavy"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "Recharge (30 seconds)\n  ",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 Lunch Box",
+				"variant": "level"
+			},
+			{
+				"text": "Eat to regain up to 300 health.\nAlt-fire: Share a Sandvich with a friend (Medium Health Kit)",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Robo-Sandvich",
+		"link": "/wiki/Robo-Sandvich",
+		"image": "/w/images/thumb/c/cb/Item_icon_Robo-Sandvich.png/100px-Item_icon_Robo-Sandvich.png",
+		"killIcon": null,
+		"releaseDate": "September 21, 2012 Patch",
+		"usedBy": ["Heavy"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "Recharge (30 seconds)\n  ",
+		"qualities": ["Genuine"],
+		"attributes": [
+			{
+				"text": "Level 1 Lunch Box",
+				"variant": "level"
+			},
+			{
+				"text": "Robots don't just run off oil. They also run off metal things constructed to resemble human food. Why? Why don't you tell me, if you're so smart? If anything, eating a metal sandwich makes MORE sense. Why don't you and oil have a baby that you have shared custody of after you and oil have a messy divorce if you love oil so much?",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Dalokohs Bar",
+		"link": "/wiki/Dalokohs_Bar",
+		"image": "/w/images/thumb/3/35/Item_icon_Dalokohs_Bar.png/100px-Item_icon_Dalokohs_Bar.png",
+		"killIcon": null,
+		"releaseDate": "March 18, 2010 Patch(First Community Contribution Update)",
+		"usedBy": ["Heavy"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "Recharge (10 Seconds)\n  ",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 Lunch Box",
+				"variant": "level"
+			},
+			{
+				"text": "Adds +50 max health for 30 seconds",
+				"variant": "positive"
+			},
+			{
+				"text": "Eat to gain up to 100 health.\nAlt-fire: Share chocolate with a friend (Small Health Kit)",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Fishcake",
+		"link": "/wiki/Fishcake",
+		"image": "/w/images/thumb/9/94/Item_icon_Fishcake.png/100px-Item_icon_Fishcake.png",
+		"killIcon": null,
+		"releaseDate": "April 28, 2011 Patch",
+		"usedBy": ["Heavy"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "Recharge (10 seconds)\n",
+		"qualities": ["Unique"],
+		"attributes": [
+			{
+				"text": "Level 1 Fishcake",
+				"variant": "level"
+			},
+			{
+				"text": "Adds +50 max health for 30 seconds",
+				"variant": "positive"
+			},
+			{
+				"text": "Eat to gain up to 100 health.\nAlt-fire: Share with a friend (Small Health Kit)\n\nVossler Industries All-Natural Artificial-Fish-Derived Food Product",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Buffalo Steak Sandvich",
+		"link": "/wiki/Buffalo_Steak_Sandvich",
+		"image": "/w/images/thumb/6/62/Item_icon_Buffalo_Steak_Sandvich.png/100px-Item_icon_Buffalo_Steak_Sandvich.png",
+		"killIcon": null,
+		"releaseDate": "December 17, 2010 Patch(Australian Christmas)",
+		"usedBy": ["Heavy"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "Recharge (30 Seconds)\n  ",
+		"qualities": ["Unique", "Vintage", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 Lunch Box",
+				"variant": "level"
+			},
+			{
+				"text": "+20% damage vulnerability while active",
+				"variant": "negative"
+			},
+			{
+				"text": "After consuming, move speed is increased, attacks mini-crit, and the player may only use melee weapons. Lasts 16 seconds.\nAlt-fire: Share with a friend (Medium Health Kit)\n\nWho needs bread?",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Fists",
+		"link": "/wiki/Fists",
+		"image": "/w/images/thumb/1/19/Item_icon_Fists.png/100px-Item_icon_Fists.png",
+		"killIcon": "/w/images/2/27/Killicon_fists.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Heavy"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Normal", "Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "Level 1 Fists",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Apoco-Fists",
+		"link": "/wiki/Apoco-Fists",
+		"image": "/w/images/thumb/9/91/Item_icon_Apoco-Fists.png/100px-Item_icon_Apoco-Fists.png",
+		"killIcon": "/w/images/2/23/Killicon_apoco-fists.png",
+		"releaseDate": "November 10, 2011 Patch",
+		"usedBy": ["Heavy"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Genuine", "Strange"],
+		"attributes": [
+			{
+				"text": "Level 10 Fists",
+				"variant": "level"
+			},
+			{
+				"text": "Killing an enemy with a critical hit will dismember your victim. Painfully.",
+				"variant": "positive"
+			},
+			{
+				"text": "Turn every one of your fingers into the Four Horsemen of the Apocalypse! That's over nineteen Horsemen of the Apocalypse per glove! The most Apocalypse we've ever dared attach to one hand!",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Killing Gloves of Boxing",
+		"link": "/wiki/Killing_Gloves_of_Boxing",
+		"image": "/w/images/thumb/f/f6/Item_icon_Killing_Gloves_of_Boxing.png/100px-Item_icon_Killing_Gloves_of_Boxing.png",
+		"killIcon": "/w/images/f/f3/Killicon_killing_gloves_of_boxing.png",
+		"releaseDate": "August 19, 2008 Patch(Heavy Update)",
+		"usedBy": ["Heavy"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 7 Boxing Gloves",
+				"variant": "level"
+			},
+			{
+				"text": "On Kill: 5 seconds of 100% critical chance",
+				"variant": "positive"
+			},
+			{
+				"text": "20% slower firing speed",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Gloves of Running Urgently",
+		"link": "/wiki/Gloves_of_Running_Urgently",
+		"image": "/w/images/thumb/4/4f/Item_icon_Gloves_of_Running_Urgently.png/100px-Item_icon_Gloves_of_Running_Urgently.png",
+		"killIcon": "/w/images/1/13/Killicon_gloves_of_running_urgently.png",
+		"releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
+		"usedBy": ["Heavy"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Boxing Gloves",
+				"variant": "level"
+			},
+			{
+				"text": "+30% faster move speed on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "This weapon holsters 50% slower",
+				"variant": "negative"
+			},
+			{
+				"text": "Maximum health is drained while item is active",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Bread Bite",
+		"link": "/wiki/Bread_Bite",
+		"image": "/w/images/thumb/a/a4/Item_icon_Bread_Bite.png/100px-Item_icon_Bread_Bite.png",
+		"killIcon": "/w/images/4/4f/Killicon_bread_bite.png",
+		"releaseDate": "June 18, 2014 Patch(Love & War Update)",
+		"usedBy": ["Heavy"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "+30% faster move speed on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "This weapon holsters 50% slower",
+				"variant": "negative"
+			},
+			{
+				"text": "Maximum health is drained while item is active",
+				"variant": "negative"
+			},
+			{
+				"text": "Inspired by the TF2 Movie 'Expiration Date'",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Warrior's Spirit",
+		"link": "/wiki/Warrior%27s_Spirit",
+		"image": "/w/images/thumb/8/87/Item_icon_Warrior%27s_Spirit.png/100px-Item_icon_Warrior%27s_Spirit.png",
+		"killIcon": "/w/images/d/d8/Killicon_warrior%27s_spirit.png",
+		"releaseDate": "December 17, 2010 Patch(Australian Christmas)",
+		"usedBy": ["Heavy"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Boxing Gloves",
+				"variant": "level"
+			},
+			{
+				"text": " When weapon is active: ",
+				"variant": "neutral"
+			},
+			{
+				"text": "+30% damage bonus",
+				"variant": "positive"
+			},
+			{
+				"text": "+50 health restored on kill",
+				"variant": "positive"
+			},
+			{
+				"text": "30% damage vulnerability on wearer",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Fists of Steel",
+		"link": "/wiki/Fists_of_Steel",
+		"image": "/w/images/thumb/9/9c/Item_icon_Fists_of_Steel.png/100px-Item_icon_Fists_of_Steel.png",
+		"killIcon": "/w/images/c/ce/Killicon_fists_of_steel.png",
+		"releaseDate": "December 17, 2010 Patch(Australian Christmas)",
+		"usedBy": ["Heavy"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Boxing Gloves",
+				"variant": "level"
+			},
+			{
+				"text": "-40% damage from ranged sources while active",
+				"variant": "positive"
+			},
+			{
+				"text": "+100% damage from melee sources while active",
+				"variant": "negative"
+			},
+			{
+				"text": "This weapon holsters 100% slower",
+				"variant": "negative"
+			},
+			{
+				"text": "-40% maximum overheal on wearer",
+				"variant": "negative"
+			},
+			{
+				"text": "-40% health from healers on wearer",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Eviction Notice",
+		"link": "/wiki/Eviction_Notice",
+		"image": "/w/images/thumb/6/62/Item_icon_Eviction_Notice.png/100px-Item_icon_Eviction_Notice.png",
+		"killIcon": "/w/images/4/44/Killicon_eviction_notice.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Heavy"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Boxing Gloves",
+				"variant": "level"
+			},
+			{
+				"text": "+40% faster firing speed",
+				"variant": "positive"
+			},
+			{
+				"text": "On Hit: Gain a speed boost",
+				"variant": "positive"
+			},
+			{
+				"text": "+15% faster move speed on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "-60% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "Maximum health is drained while item is active",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Holiday Punch",
+		"link": "/wiki/Holiday_Punch",
+		"image": "/w/images/thumb/5/54/Item_icon_Holiday_Punch.png/100px-Item_icon_Holiday_Punch.png",
+		"killIcon": "/w/images/1/11/Killicon_holiday_punch.png",
+		"releaseDate": "December 15, 2011 Patch(Australian Christmas 2011)",
+		"usedBy": ["Heavy"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Fists",
+				"variant": "level"
+			},
+			{
+				"text": "Critical hit forces victim to laugh",
+				"variant": "positive"
+			},
+			{
+				"text": "Always critical hit from behind",
+				"variant": "positive"
+			},
+			{
+				"text": "On Hit: Force enemies to laugh who are also wearing this item",
+				"variant": "positive"
+			},
+			{
+				"text": "Critical hits do no damage",
+				"variant": "negative"
+			},
+			{
+				"text": "Be the life of the war party with these laugh-inducing punch-mittens.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Frontier Justice",
+		"link": "/wiki/Frontier_Justice",
+		"image": "/w/images/thumb/2/26/Item_icon_Frontier_Justice.png/100px-Item_icon_Frontier_Justice.png",
+		"killIcon": "/w/images/c/c8/Killicon_frontier_justice.png",
+		"releaseDate": "July 8, 2010 Patch(Engineer Update)",
+		"usedBy": ["Engineer"],
+		"slot": ["Primary"],
+		"ammoLoaded": "3",
+		"ammoCarried": "32",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Shotgun",
+				"variant": "level"
+			},
+			{
+				"text": "Gain 2 revenge crits for each sentry kill and\n1 for each sentry assist when your sentry is destroyed",
+				"variant": "positive"
+			},
+			{
+				"text": "-50% clip size",
+				"variant": "negative"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "Revenge crits are lost on death",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Widowmaker",
+		"link": "/wiki/Widowmaker",
+		"image": "/w/images/thumb/b/b8/Item_icon_Widowmaker.png/100px-Item_icon_Widowmaker.png",
+		"killIcon": "/w/images/0/0a/Killicon_widowmaker.png",
+		"releaseDate": "August 18, 2011 Patch(Manno-Technology Bundle)",
+		"usedBy": ["Engineer"],
+		"slot": ["Primary"],
+		"ammoLoaded": "1 per 30 Metal",
+		"ammoCarried": "200 Metal (allows 6 shots)",
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Genuine", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Shotgun",
+				"variant": "level"
+			},
+			{
+				"text": "On Hit: damage dealt is returned as ammo",
+				"variant": "positive"
+			},
+			{
+				"text": "No reload necessary",
+				"variant": "positive"
+			},
+			{
+				"text": "10% increased damage to your sentry's target",
+				"variant": "positive"
+			},
+			{
+				"text": "Per Shot: -30 ammo",
+				"variant": "negative"
+			},
+			{
+				"text": "Uses metal for ammo",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Pomson 6000",
+		"link": "/wiki/Pomson_6000",
+		"image": "/w/images/thumb/8/89/Item_icon_Pomson_6000.png/100px-Item_icon_Pomson_6000.png",
+		"killIcon": "/w/images/b/b5/Killicon_pomson_6000.png",
+		"releaseDate": "December 15, 2011 Patch(Australian Christmas 2011)",
+		"usedBy": ["Engineer"],
+		"slot": ["Primary"],
+		"ammoLoaded": "4",
+		"ammoCarried": "Unlimited",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Indivisible Particle Smasher",
+				"variant": "level"
+			},
+			{
+				"text": "Does not require ammo",
+				"variant": "positive"
+			},
+			{
+				"text": "Projectile cannot be deflected",
+				"variant": "positive"
+			},
+			{
+				"text": "On Hit: Victim loses up to 10% Medigun charge",
+				"variant": "positive"
+			},
+			{
+				"text": "On Hit: Victim loses up to 20% cloak",
+				"variant": "positive"
+			},
+			{
+				"text": "Deals only 20% damage to buildings",
+				"variant": "negative"
+			},
+			{
+				"text": "Being an innovative hand-held irradiating utensil capable of producing rapid pulses of high-amplitude radiation in sufficient quantity as to immolate, maim and otherwise incapacitate the Irish.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Rescue Ranger",
+		"link": "/wiki/Rescue_Ranger",
+		"image": "/w/images/thumb/2/29/Item_icon_Rescue_Ranger.png/100px-Item_icon_Rescue_Ranger.png",
+		"killIcon": "/w/images/1/14/Killicon_rescue_ranger.png",
+		"releaseDate": "December 20, 2012 Patch(Mecha Update)",
+		"usedBy": ["Engineer"],
+		"slot": ["Primary"],
+		"ammoLoaded": "4",
+		"ammoCarried": "16",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Shotgun",
+				"variant": "level"
+			},
+			{
+				"text": "Alt-Fire: Use 100 metal to pick up your targeted building from long range",
+				"variant": "positive"
+			},
+			{
+				"text": "Fires a special bolt that can repair friendly buildings",
+				"variant": "positive"
+			},
+			{
+				"text": "-34% clip size",
+				"variant": "negative"
+			},
+			{
+				"text": "-50% max primary ammo on wearer",
+				"variant": "negative"
+			},
+			{
+				"text": "Self mark for death when hauling buildings",
+				"variant": "negative"
+			},
+			{
+				"text": "4-to-1 health-to-metal ratio when repairing buildings",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Wrangler",
+		"link": "/wiki/Wrangler",
+		"image": "/w/images/thumb/c/ce/Item_icon_Wrangler.png/100px-Item_icon_Wrangler.png",
+		"killIcon": "/w/images/e/e0/Killicon_wrangler.png",
+		"releaseDate": "July 8, 2010 Patch(Engineer Update)",
+		"usedBy": ["Engineer"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Laser Pointer",
+				"variant": "level"
+			},
+			{
+				"text": "Take manual control of your Sentry Gun.\nWrangled sentries gain a shield that reduces\ndamage and repairs by 66%.\nSentries are disabled for 3 seconds after becoming unwrangled.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Giger Counter",
+		"link": "/wiki/Giger_Counter",
+		"image": "/w/images/thumb/5/5d/Item_icon_Giger_Counter.png/100px-Item_icon_Giger_Counter.png",
+		"killIcon": "/w/images/0/03/Killicon_giger_counter.png",
+		"releaseDate": "October 6, 2015 Patch(Invasion Community Update)",
+		"usedBy": ["Engineer"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "\nLaser Pointer",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Short Circuit",
+		"link": "/wiki/Short_Circuit",
+		"image": "/w/images/thumb/3/36/Item_icon_Short_Circuit.png/100px-Item_icon_Short_Circuit.png",
+		"killIcon": "/w/images/1/10/Killicon_short_circuit.png",
+		"releaseDate": "August 18, 2011 Patch(Manno-Technology Bundle)",
+		"usedBy": ["Engineer"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "1 per 5 Metal",
+		"ammoCarried": "200 Metal (allows 40 uses)",
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Genuine", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Robot Arm",
+				"variant": "level"
+			},
+			{
+				"text": "Alt-Fire: Launches a projectile-consuming energy ball.  Costs 65 metal.",
+				"variant": "positive"
+			},
+			{
+				"text": "No reload necessary",
+				"variant": "positive"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "Per Shot: -5 ammo",
+				"variant": "negative"
+			},
+			{
+				"text": "Uses metal for ammo",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Wrench",
+		"link": "/wiki/Wrench",
+		"image": "/w/images/thumb/7/7d/Item_icon_Wrench.png/100px-Item_icon_Wrench.png",
+		"killIcon": "/w/images/7/7a/Killicon_wrench.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Engineer"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Normal", "Unique", "Strange", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 Wrench",
+				"variant": "level"
+			},
+			{
+				"text": "Upgrades, repairs and speeds up construction of friendly buildings on hit",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Golden Wrench",
+		"link": "/wiki/Golden_Wrench",
+		"image": "/w/images/thumb/9/95/Item_icon_Golden_Wrench.png/100px-Item_icon_Golden_Wrench.png",
+		"killIcon": "/w/images/0/0e/Killicon_golden_wrench.png",
+		"releaseDate": "July 1, 2010 Patch",
+		"usedBy": ["Engineer"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique"],
+		"attributes": [
+			{
+				"text": "Imbued with an ancient power",
+				"variant": "positive"
+			},
+			{
+				"text": "Wrench no. [#]",
+				"variant": "neutral"
+			},
+			{
+				"text": "( Not Tradable or Marketable )",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Gunslinger",
+		"link": "/wiki/Gunslinger",
+		"image": "/w/images/thumb/c/ca/Item_icon_Gunslinger.png/100px-Item_icon_Gunslinger.png",
+		"killIcon": "/w/images/b/b2/Killicon_gunslinger.png",
+		"releaseDate": "July 8, 2010 Patch(Engineer Update)",
+		"usedBy": ["Engineer"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 15 Robot Arm",
+				"variant": "level"
+			},
+			{
+				"text": "+25 max health on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "Sentry build speed increased by 150%",
+				"variant": "positive"
+			},
+			{
+				"text": "Third successful punch in a row always crits",
+				"variant": "positive"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "Replaces the Sentry with a Mini-Sentry",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Southern Hospitality",
+		"link": "/wiki/Southern_Hospitality",
+		"image": "/w/images/thumb/e/ec/Item_icon_Southern_Hospitality.png/100px-Item_icon_Southern_Hospitality.png",
+		"killIcon": "/w/images/1/1d/Killicon_southern_hospitality.png",
+		"releaseDate": "July 8, 2010 Patch(Engineer Update)",
+		"usedBy": ["Engineer"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 20 Wrench",
+				"variant": "level"
+			},
+			{
+				"text": "On Hit: Bleed for 5 seconds",
+				"variant": "positive"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "20% fire damage vulnerability on wearer",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Jag",
+		"link": "/wiki/Jag",
+		"image": "/w/images/thumb/4/49/Item_icon_Jag.png/100px-Item_icon_Jag.png",
+		"killIcon": "/w/images/0/0c/Killicon_jag.png",
+		"releaseDate": "December 17, 2010 Patch(Australian Christmas)",
+		"usedBy": ["Engineer"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 15 Wrench",
+				"variant": "level"
+			},
+			{
+				"text": "Construction hit speed boost increased by 30%",
+				"variant": "positive"
+			},
+			{
+				"text": "+15% faster firing speed",
+				"variant": "positive"
+			},
+			{
+				"text": "-25% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "20% slower repair rate",
+				"variant": "negative"
+			},
+			{
+				"text": "-33% damage penalty vs buildings",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Eureka Effect",
+		"link": "/wiki/Eureka_Effect",
+		"image": "/w/images/thumb/c/cf/Item_icon_Eureka_Effect.png/100px-Item_icon_Eureka_Effect.png",
+		"killIcon": "/w/images/2/2c/Killicon_eureka_effect.png",
+		"releaseDate": "December 15, 2011 Patch(Australian Christmas 2011)",
+		"usedBy": ["Engineer"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 20 Wrench",
+				"variant": "level"
+			},
+			{
+				"text": "Press your reload key to choose to teleport to spawn or your exit teleporter",
+				"variant": "positive"
+			},
+			{
+				"text": "-50% metal cost when constructing or upgrading teleporters",
+				"variant": "positive"
+			},
+			{
+				"text": "Construction hit speed boost decreased by 50%",
+				"variant": "negative"
+			},
+			{
+				"text": "20% less metal from pickups and dispensers",
+				"variant": "negative"
+			},
+			{
+				"text": "Being a tool that eliminates exertion by harnessing the electrical discharges of thunder-storms for the vigorous coercion of bolts, nuts, pipes and similar into their rightful places. May also be used to bludgeon.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Destruction PDA",
+		"link": "/wiki/PDA",
+		"image": "/w/images/thumb/2/26/Item_icon_PDA_Destroy.png/100px-Item_icon_PDA_Destroy.png",
+		"killIcon": null,
+		"releaseDate": "unknown",
+		"usedBy": ["Engineer"],
+		"slot": ["PDA 1", "PDA 2"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Normal", "Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "Level 1 PDA",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Syringe Gun",
+		"link": "/wiki/Syringe_Gun",
+		"image": "/w/images/thumb/c/c4/Item_icon_Syringe_Gun.png/100px-Item_icon_Syringe_Gun.png",
+		"killIcon": "/w/images/8/8b/Killicon_syringe_gun.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Medic"],
+		"slot": ["Primary"],
+		"ammoLoaded": "40",
+		"ammoCarried": "150",
+		"reloadType": "Clip\n  ",
+		"qualities": ["Normal", "Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "Level 1 Syringe Gun",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Blutsauger",
+		"link": "/wiki/Blutsauger",
+		"image": "/w/images/thumb/1/13/Item_icon_Blutsauger.png/100px-Item_icon_Blutsauger.png",
+		"killIcon": "/w/images/b/b6/Killicon_blutsauger.png",
+		"releaseDate": "April 29, 2008 Patch(Gold Rush Update)",
+		"usedBy": ["Medic"],
+		"slot": ["Primary"],
+		"ammoLoaded": "40",
+		"ammoCarried": "150",
+		"reloadType": "Clip\n  ",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Syringe Gun",
+				"variant": "level"
+			},
+			{
+				"text": "On Hit: Gain up to +3 health",
+				"variant": "positive"
+			},
+			{
+				"text": "-2 health regenerated per second on wearer",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Crusader's Crossbow",
+		"link": "/wiki/Crusader%27s_Crossbow",
+		"image": "/w/images/thumb/9/9c/Item_icon_Crusader%27s_Crossbow.png/100px-Item_icon_Crusader%27s_Crossbow.png",
+		"killIcon": "/w/images/9/95/Killicon_crusader%27s_crossbow.png",
+		"releaseDate": "December 17, 2010 Patch(Australian Christmas)",
+		"usedBy": ["Medic"],
+		"slot": ["Primary"],
+		"ammoLoaded": "1",
+		"ammoCarried": "38",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 15 Crossbow",
+				"variant": "level"
+			},
+			{
+				"text": "No headshots",
+				"variant": "negative"
+			},
+			{
+				"text": "-75% max primary ammo on wearer",
+				"variant": "negative"
+			},
+			{
+				"text": "Fires special bolts that heal teammates and deals damage\nbased on distance traveled\nThis weapon will reload automatically when not active",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Overdose",
+		"link": "/wiki/Overdose",
+		"image": "/w/images/thumb/f/fe/Item_icon_Overdose.png/100px-Item_icon_Overdose.png",
+		"killIcon": "/w/images/8/8d/Killicon_overdose.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Medic"],
+		"slot": ["Primary"],
+		"ammoLoaded": "40",
+		"ammoCarried": "150",
+		"reloadType": "Clip\n  ",
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Syringe Gun Prototype",
+				"variant": "level"
+			},
+			{
+				"text": "-15% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "While active, movement speed increases based on \u00dcberCharge percentage to a maximum of +20%",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Medi Gun",
+		"link": "/wiki/Medi_Gun",
+		"image": "/w/images/thumb/4/4a/Item_icon_Medi_Gun.png/100px-Item_icon_Medi_Gun.png",
+		"killIcon": null,
+		"releaseDate": "unknown",
+		"usedBy": ["Medic"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Normal", "Unique", "Strange", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 Medi Gun",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Kritzkrieg",
+		"link": "/wiki/Kritzkrieg",
+		"image": "/w/images/thumb/8/85/Item_icon_Kritzkrieg.png/100px-Item_icon_Kritzkrieg.png",
+		"killIcon": null,
+		"releaseDate": "April 29, 2008 Patch(Gold Rush Update)",
+		"usedBy": ["Medic"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 8 Medi Gun",
+				"variant": "level"
+			},
+			{
+				"text": " \u00dcberCharge grants 100% critical chance ",
+				"variant": "neutral"
+			},
+			{
+				"text": "+25% \u00dcberCharge rate",
+				"variant": "positive"
+			}
+		]
+	},
+	{
+		"name": "Quick-Fix",
+		"link": "/wiki/Quick-Fix",
+		"image": "/w/images/thumb/5/50/Item_icon_Quick-Fix.png/100px-Item_icon_Quick-Fix.png",
+		"killIcon": null,
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Medic"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 8 Medi Gun Prototype",
+				"variant": "level"
+			},
+			{
+				"text": " \u00dcberCharge increases healing to 300% and grants immunity to movement-impairing effects ",
+				"variant": "neutral"
+			},
+			{
+				"text": "+40% heal rate",
+				"variant": "positive"
+			},
+			{
+				"text": "+10% \u00dcberCharge rate",
+				"variant": "positive"
+			},
+			{
+				"text": "50% max overheal",
+				"variant": "negative"
+			},
+			{
+				"text": "Mirror the blast jumps and shield charges of patients.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Vaccinator",
+		"link": "/wiki/Vaccinator",
+		"image": "/w/images/thumb/9/9d/Item_icon_Vaccinator.png/100px-Item_icon_Vaccinator.png",
+		"killIcon": null,
+		"releaseDate": "December 20, 2012 Patch(Mecha Update)",
+		"usedBy": ["Medic"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 8 Vaccinator",
+				"variant": "level"
+			},
+			{
+				"text": "+67% \u00dcberCharge rate",
+				"variant": "positive"
+			},
+			{
+				"text": "Press your reload key to cycle through resist types.\nWhile healing, provides you and your target with a constant 10% resistance to the selected damage type.",
+				"variant": "positive"
+			},
+			{
+				"text": "-33% \u00dcberCharge rate on Overhealed patients",
+				"variant": "negative"
+			},
+			{
+				"text": "-66% Overheal build rate",
+				"variant": "negative"
+			},
+			{
+				"text": "\u00dcberCharge provides a 2.5 second resistance bubble that blocks 75% base damage and 100% crit damage of the selected type to the Medic and Patient.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Bonesaw",
+		"link": "/wiki/Bonesaw",
+		"image": "/w/images/thumb/8/8d/Item_icon_Bonesaw.png/100px-Item_icon_Bonesaw.png",
+		"killIcon": "/w/images/0/08/Killicon_bonesaw.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Medic"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Normal", "Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "Level 1 Bonesaw",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Ubersaw",
+		"link": "/wiki/Ubersaw",
+		"image": "/w/images/thumb/0/04/Item_icon_Ubersaw.png/100px-Item_icon_Ubersaw.png",
+		"killIcon": "/w/images/9/9a/Killicon_ubersaw.png",
+		"releaseDate": "April 29, 2008 Patch(Gold Rush Update)",
+		"usedBy": ["Medic"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 10 Bonesaw",
+				"variant": "level"
+			},
+			{
+				"text": "On Hit: 25% \u00dcberCharge added",
+				"variant": "positive"
+			},
+			{
+				"text": "20% slower firing speed",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Vita-Saw",
+		"link": "/wiki/Vita-Saw",
+		"image": "/w/images/thumb/7/70/Item_icon_Vita-Saw.png/100px-Item_icon_Vita-Saw.png",
+		"killIcon": "/w/images/c/c3/Killicon_vita-saw.png",
+		"releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
+		"usedBy": ["Medic"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Bonesaw",
+				"variant": "level"
+			},
+			{
+				"text": "Collect the organs of people you hit",
+				"variant": "positive"
+			},
+			{
+				"text": "-10 max health on wearer",
+				"variant": "negative"
+			},
+			{
+				"text": "A percentage of your \u00dcberCharge level is retained on death, based on the number of organs harvested (15% per). Total \u00dcberCharge retained on spawn caps at 60%.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Amputator",
+		"link": "/wiki/Amputator",
+		"image": "/w/images/thumb/a/ab/Item_icon_Amputator.png/100px-Item_icon_Amputator.png",
+		"killIcon": "/w/images/3/35/Killicon_amputator.png",
+		"releaseDate": "December 17, 2010 Patch(Australian Christmas)",
+		"usedBy": ["Medic"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 15 Bonesaw",
+				"variant": "level"
+			},
+			{
+				"text": " When weapon is active: ",
+				"variant": "neutral"
+			},
+			{
+				"text": "+3 health regenerated per second on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "Alt-Fire: Applies a healing effect to all nearby teammates",
+				"variant": "positive"
+			},
+			{
+				"text": "-20% damage penalty",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Solemn Vow",
+		"link": "/wiki/Solemn_Vow",
+		"image": "/w/images/thumb/d/db/Item_icon_Solemn_Vow.png/100px-Item_icon_Solemn_Vow.png",
+		"killIcon": "/w/images/9/98/Killicon_solemn_vow.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Medic"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Bust of Hippocrates",
+				"variant": "level"
+			},
+			{
+				"text": "Allows you to see enemy health",
+				"variant": "positive"
+			},
+			{
+				"text": "10% slower firing speed",
+				"variant": "negative"
+			},
+			{
+				"text": "'Do no harm.'",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Sniper Rifle",
+		"link": "/wiki/Sniper_Rifle",
+		"image": "/w/images/thumb/a/a1/Item_icon_Sniper_Rifle.png/100px-Item_icon_Sniper_Rifle.png",
+		"killIcon": "/w/images/f/fe/Killicon_sniper_rifle.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Sniper"],
+		"slot": ["Primary"],
+		"ammoLoaded": "25",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Normal", "Unique", "Strange", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 Sniper Rifle",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "AWPer Hand",
+		"link": "/wiki/AWPer_Hand",
+		"image": "/w/images/thumb/2/24/Item_icon_AWPer_Hand.png/100px-Item_icon_AWPer_Hand.png",
+		"killIcon": "/w/images/f/fe/Killicon_sniper_rifle.png",
+		"releaseDate": "August 15, 2012 Patch",
+		"usedBy": ["Sniper"],
+		"slot": ["Primary"],
+		"ammoLoaded": "25",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Genuine", "Strange"],
+		"attributes": [
+			{
+				"text": "Level 1 Sniper Rifle",
+				"variant": "level"
+			},
+			{
+				"text": "This controversial bolt-action beaut is banned in thousands of countries, and with good reason: You could really hurt someone with this thing.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Huntsman",
+		"link": "/wiki/Huntsman",
+		"image": "/w/images/thumb/f/f8/Item_icon_Huntsman.png/100px-Item_icon_Huntsman.png",
+		"killIcon": "/w/images/a/ad/Killicon_huntsman.png",
+		"releaseDate": "May 21, 2009 Patch(Sniper vs. Spy Update)",
+		"usedBy": ["Sniper"],
+		"slot": ["Primary"],
+		"ammoLoaded": "1",
+		"ammoCarried": "12",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Bow",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Fortified Compound",
+		"link": "/wiki/Fortified_Compound",
+		"image": "/w/images/thumb/8/89/Item_icon_Fortified_Compound.png/100px-Item_icon_Fortified_Compound.png",
+		"killIcon": "/w/images/a/ad/Killicon_huntsman.png",
+		"releaseDate": "February 11, 2014 Patch",
+		"usedBy": ["Sniper"],
+		"slot": ["Primary"],
+		"ammoLoaded": "1",
+		"ammoCarried": "12",
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Genuine", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Bow",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Sydney Sleeper",
+		"link": "/wiki/Sydney_Sleeper",
+		"image": "/w/images/thumb/6/6a/Item_icon_Sydney_Sleeper.png/100px-Item_icon_Sydney_Sleeper.png",
+		"killIcon": "/w/images/3/3b/Killicon_sydney_sleeper.png",
+		"releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
+		"usedBy": ["Sniper"],
+		"slot": ["Primary"],
+		"ammoLoaded": "25",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 Sniper Rifle",
+				"variant": "level"
+			},
+			{
+				"text": "+25% charge rate",
+				"variant": "positive"
+			},
+			{
+				"text": "On Scoped Hit: Apply Jarate for 2 to 5 seconds based on charge level.\nNature's Call: Scoped headshots always mini-crit and reduce the remaining cooldown of Jarate by 1 second.",
+				"variant": "positive"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "No headshots",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Bazaar Bargain",
+		"link": "/wiki/Bazaar_Bargain",
+		"image": "/w/images/thumb/f/f4/Item_icon_Bazaar_Bargain.png/100px-Item_icon_Bazaar_Bargain.png",
+		"killIcon": "/w/images/6/60/Killicon_bazaar_bargain.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Sniper"],
+		"slot": ["Primary"],
+		"ammoLoaded": "25",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 10 Sniper Rifle",
+				"variant": "level"
+			},
+			{
+				"text": "Base charge rate decreased by 50%",
+				"variant": "negative"
+			},
+			{
+				"text": "Each scoped headshot kill increases the weapon's charge rate by 25% up to 200%.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Machina",
+		"link": "/wiki/Machina",
+		"image": "/w/images/thumb/a/ae/Item_icon_Machina.png/100px-Item_icon_Machina.png",
+		"killIcon": "/w/images/0/09/Killicon_machina.png",
+		"releaseDate": "August 18, 2011 Patch(Manno-Technology Bundle)",
+		"usedBy": ["Sniper"],
+		"slot": ["Primary"],
+		"ammoLoaded": "25",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Genuine", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Sniper Rifle",
+				"variant": "level"
+			},
+			{
+				"text": "On Full Charge: +15% damage per shot",
+				"variant": "positive"
+			},
+			{
+				"text": "On Full Charge: Projectiles penetrate players",
+				"variant": "positive"
+			},
+			{
+				"text": "Cannot fire unless zoomed",
+				"variant": "negative"
+			},
+			{
+				"text": "Fires tracer rounds",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Shooting Star",
+		"link": "/wiki/Shooting_Star",
+		"image": "/w/images/thumb/d/d7/Item_icon_Shooting_Star.png/100px-Item_icon_Shooting_Star.png",
+		"killIcon": "/w/images/5/51/Killicon_shooting_star.png",
+		"releaseDate": "October 6, 2015 Patch(Invasion Community Update)",
+		"usedBy": ["Sniper"],
+		"slot": ["Primary"],
+		"ammoLoaded": "25",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "\nSniper Rifle",
+				"variant": "level"
+			},
+			{
+				"text": "On Full Charge: +15% damage per shot",
+				"variant": "positive"
+			},
+			{
+				"text": "On Full Charge: Projectiles penetrate players",
+				"variant": "positive"
+			},
+			{
+				"text": "Cannot fire unless zoomed",
+				"variant": "negative"
+			},
+			{
+				"text": "Fires tracer rounds",
+				"variant": "negative"
+			},
+			{
+				"text": "Turn your enemies in to ash!",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Hitman's Heatmaker",
+		"link": "/wiki/Hitman%27s_Heatmaker",
+		"image": "/w/images/thumb/1/18/Item_icon_Hitman%27s_Heatmaker.png/100px-Item_icon_Hitman%27s_Heatmaker.png",
+		"killIcon": "/w/images/1/17/Killicon_hitman%27s_heatmaker.png",
+		"releaseDate": "June 27, 2012 Patch(Pyromania Update)",
+		"usedBy": ["Sniper"],
+		"slot": ["Primary"],
+		"ammoLoaded": "25",
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 Sniper Rifle",
+				"variant": "level"
+			},
+			{
+				"text": "Gain Focus on kills and assists",
+				"variant": "positive"
+			},
+			{
+				"text": "Press 'Reload' to activate focus\nIn Focus: +25% faster charge and no unscoping",
+				"variant": "positive"
+			},
+			{
+				"text": "-20% damage on body shot",
+				"variant": "negative"
+			},
+			{
+				"text": "Heads will roll.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Classic",
+		"link": "/wiki/Classic",
+		"image": "/w/images/thumb/7/73/Item_icon_Classic.png/100px-Item_icon_Classic.png",
+		"killIcon": "/w/images/4/40/Killicon_classic.png",
+		"releaseDate": "June 18, 2014 Patch(Love & War Update)",
+		"usedBy": ["Sniper"],
+		"slot": ["Primary"],
+		"ammoLoaded": "25",
+		"ammoCarried": null,
+		"reloadType": "Single\n  ",
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Sniper Rifle",
+				"variant": "level"
+			},
+			{
+				"text": "Charge and fire shots independent of zoom",
+				"variant": "positive"
+			},
+			{
+				"text": "No headshots when not fully charged",
+				"variant": "negative"
+			},
+			{
+				"text": "-10% damage on body shot",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "SMG",
+		"link": "/wiki/SMG",
+		"image": "/w/images/thumb/5/50/Item_icon_SMG.png/100px-Item_icon_SMG.png",
+		"killIcon": "/w/images/5/51/Killicon_SMG.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Sniper"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "25",
+		"ammoCarried": "75",
+		"reloadType": "Clip\n  ",
+		"qualities": ["Normal", "Unique", "Strange", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 SMG",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Cleaner's Carbine",
+		"link": "/wiki/Cleaner%27s_Carbine",
+		"image": "/w/images/thumb/6/64/Item_icon_Cleaner%27s_Carbine.png/100px-Item_icon_Cleaner%27s_Carbine.png",
+		"killIcon": "/w/images/8/81/Killicon_cleaner%27s_carbine.png",
+		"releaseDate": "June 27, 2012 Patch(Pyromania Update)",
+		"usedBy": ["Sniper"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "20",
+		"ammoCarried": "75",
+		"reloadType": "Clip\n  ",
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 SMG",
+				"variant": "level"
+			},
+			{
+				"text": "Secondary fire when charged grants mini-crits for 8 seconds",
+				"variant": "positive"
+			},
+			{
+				"text": "Dealing damage fills charge meter",
+				"variant": "positive"
+			},
+			{
+				"text": "-20% clip size",
+				"variant": "negative"
+			},
+			{
+				"text": "25% slower firing speed",
+				"variant": "negative"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Jarate",
+		"link": "/wiki/Jarate",
+		"image": "/w/images/thumb/b/b3/Item_icon_Jarate.png/100px-Item_icon_Jarate.png",
+		"killIcon": null,
+		"releaseDate": "May 21, 2009 Patch(Sniper vs. Spy Update)",
+		"usedBy": ["Sniper"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "Recharge (20 Seconds)\n  ",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Jar Based Karate",
+				"variant": "level"
+			},
+			{
+				"text": " Coated enemies take mini-crits\nCan be used to extinguish fires ",
+				"variant": "neutral"
+			},
+			{
+				"text": "Extinguishing teammates reduces cooldown by -20%",
+				"variant": "positive"
+			}
+		]
+	},
+	{
+		"name": "Self-Aware Beauty Mark",
+		"link": "/wiki/Self-Aware_Beauty_Mark",
+		"image": "/w/images/thumb/2/2e/Item_icon_Self-Aware_Beauty_Mark.png/100px-Item_icon_Self-Aware_Beauty_Mark.png",
+		"killIcon": null,
+		"releaseDate": "June 18, 2014 Patch(Love & War Update)",
+		"usedBy": ["Sniper"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "Recharge (20 seconds)\n  ",
+		"qualities": ["Unique", "Strange"],
+		"attributes": [
+			{
+				"text": " Coated enemies take mini-crits\nCan be used to extinguish fires ",
+				"variant": "neutral"
+			},
+			{
+				"text": "Extinguishing teammates reduces cooldown by -20%",
+				"variant": "positive"
+			},
+			{
+				"text": "Inspired by the TF2 Movie 'Expiration Date'",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Razorback",
+		"link": "/wiki/Razorback",
+		"image": "/w/images/thumb/0/0f/Item_icon_Razorback.png/100px-Item_icon_Razorback.png",
+		"killIcon": null,
+		"releaseDate": "May 21, 2009 Patch(Sniper vs. Spy Update)",
+		"usedBy": ["Sniper"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "Recharge (30 Seconds)\n  ",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Shield",
+				"variant": "level"
+			},
+			{
+				"text": "Blocks a single backstab attempt",
+				"variant": "positive"
+			},
+			{
+				"text": "-100% maximum overheal on wearer",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Darwin's Danger Shield",
+		"link": "/wiki/Darwin%27s_Danger_Shield",
+		"image": "/w/images/thumb/4/44/Item_icon_Darwin%27s_Danger_Shield.png/100px-Item_icon_Darwin%27s_Danger_Shield.png",
+		"killIcon": null,
+		"releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
+		"usedBy": ["Sniper"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Shield",
+				"variant": "level"
+			},
+			{
+				"text": "+50% fire damage resistance on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "Immune to the effects of afterburn",
+				"variant": "positive"
+			}
+		]
+	},
+	{
+		"name": "Cozy Camper",
+		"link": "/wiki/Cozy_Camper",
+		"image": "/w/images/thumb/0/01/Item_icon_Cozy_Camper.png/100px-Item_icon_Cozy_Camper.png",
+		"killIcon": null,
+		"releaseDate": "March 15, 2012 Patch",
+		"usedBy": ["Sniper"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 10 Backpack",
+				"variant": "level"
+			},
+			{
+				"text": "+4 health regenerated per second on wearer",
+				"variant": "positive"
+			},
+			{
+				"text": "No flinching when aiming and fully charged",
+				"variant": "positive"
+			},
+			{
+				"text": "Knockback reduced by 20% when aiming",
+				"variant": "positive"
+			}
+		]
+	},
+	{
+		"name": "Kukri",
+		"link": "/wiki/Kukri",
+		"image": "/w/images/thumb/e/ea/Item_icon_Kukri.png/100px-Item_icon_Kukri.png",
+		"killIcon": "/w/images/9/9d/Killicon_kukri.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Sniper"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Normal", "Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "Level 1 Kukri",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Tribalman's Shiv",
+		"link": "/wiki/Tribalman%27s_Shiv",
+		"image": "/w/images/thumb/5/55/Item_icon_Tribalman%27s_Shiv.png/100px-Item_icon_Tribalman%27s_Shiv.png",
+		"killIcon": "/w/images/c/ce/Killicon_tribalman%27s_shiv.png",
+		"releaseDate": "May 20, 2010 Patch(Second Community Contribution Update)",
+		"usedBy": ["Sniper"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Kukri",
+				"variant": "level"
+			},
+			{
+				"text": "On Hit: Bleed for 6 seconds",
+				"variant": "positive"
+			},
+			{
+				"text": "-50% damage penalty",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Bushwacka",
+		"link": "/wiki/Bushwacka",
+		"image": "/w/images/thumb/4/46/Item_icon_Bushwacka.png/100px-Item_icon_Bushwacka.png",
+		"killIcon": "/w/images/4/42/Killicon_bushwacka.png",
+		"releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
+		"usedBy": ["Sniper"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Kukri",
+				"variant": "level"
+			},
+			{
+				"text": " When weapon is active: ",
+				"variant": "neutral"
+			},
+			{
+				"text": "Crits whenever it would normally mini-crit",
+				"variant": "positive"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "20% damage vulnerability on wearer",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Shahanshah",
+		"link": "/wiki/Shahanshah",
+		"image": "/w/images/thumb/8/8d/Item_icon_Shahanshah.png/100px-Item_icon_Shahanshah.png",
+		"killIcon": "/w/images/6/6e/Killicon_shahanshah.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Sniper"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 5 Kukri",
+				"variant": "level"
+			},
+			{
+				"text": "+25% increase in damage when health <50% of max",
+				"variant": "positive"
+			},
+			{
+				"text": "-25% decrease in damage when health >50% of max",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Revolver",
+		"link": "/wiki/Revolver",
+		"image": "/w/images/thumb/1/1f/Item_icon_Revolver.png/100px-Item_icon_Revolver.png",
+		"killIcon": "/w/images/3/34/Killicon_revolver.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Spy"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "6",
+		"ammoCarried": "24",
+		"reloadType": "Clip\n  ",
+		"qualities": ["Normal", "Unique", "Strange", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 Revolver",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Big Kill",
+		"link": "/wiki/Big_Kill",
+		"image": "/w/images/thumb/3/31/Item_icon_Big_Kill.png/100px-Item_icon_Big_Kill.png",
+		"killIcon": "/w/images/e/e8/Killicon_big_kill.png",
+		"releaseDate": "April 15, 2010 Patch",
+		"usedBy": ["Spy"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "6",
+		"ammoCarried": "24",
+		"reloadType": "Clip\n  ",
+		"qualities": ["Unique"],
+		"attributes": [
+			{
+				"text": "Combines style with stopping power. Long exclusive to Freelance Police, now available for other blood-thirsty mercenaries.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Ambassador",
+		"link": "/wiki/Ambassador",
+		"image": "/w/images/thumb/e/ec/Item_icon_Ambassador.png/100px-Item_icon_Ambassador.png",
+		"killIcon": "/w/images/d/dd/Killicon_ambassador.png",
+		"releaseDate": "May 21, 2009 Patch(Sniper vs. Spy Update)",
+		"usedBy": ["Spy"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "6",
+		"ammoCarried": "24",
+		"reloadType": "Clip\n  ",
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Revolver",
+				"variant": "level"
+			},
+			{
+				"text": "Crits on headshot",
+				"variant": "positive"
+			},
+			{
+				"text": "-15% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "20% slower firing speed",
+				"variant": "negative"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			},
+			{
+				"text": "Critical damage is affected by range",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "L'Etranger",
+		"link": "/wiki/L%27Etranger",
+		"image": "/w/images/thumb/b/b1/Item_icon_L%27Etranger.png/100px-Item_icon_L%27Etranger.png",
+		"killIcon": "/w/images/8/8a/Killicon_l%27etranger.png",
+		"releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
+		"usedBy": ["Spy"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "6",
+		"ammoCarried": "24",
+		"reloadType": "Clip\n  ",
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Revolver",
+				"variant": "level"
+			},
+			{
+				"text": "+40% cloak duration",
+				"variant": "positive"
+			},
+			{
+				"text": "+15% cloak on hit",
+				"variant": "positive"
+			},
+			{
+				"text": "-20% damage penalty",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Enforcer",
+		"link": "/wiki/Enforcer",
+		"image": "/w/images/thumb/b/b6/Item_icon_Enforcer.png/100px-Item_icon_Enforcer.png",
+		"killIcon": "/w/images/7/78/Killicon_enforcer.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Spy"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "6",
+		"ammoCarried": "24",
+		"reloadType": "Clip\n  ",
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Revolver",
+				"variant": "level"
+			},
+			{
+				"text": "+20% damage bonus while disguised",
+				"variant": "positive"
+			},
+			{
+				"text": "Attacks pierce damage resistance effects and bonuses",
+				"variant": "positive"
+			},
+			{
+				"text": "20% slower firing speed",
+				"variant": "negative"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Diamondback",
+		"link": "/wiki/Diamondback",
+		"image": "/w/images/thumb/b/b4/Item_icon_Diamondback.png/100px-Item_icon_Diamondback.png",
+		"killIcon": "/w/images/c/ce/Killicon_diamondback.png",
+		"releaseDate": "August 18, 2011 Patch(Manno-Technology Bundle)",
+		"usedBy": ["Spy"],
+		"slot": ["Secondary"],
+		"ammoLoaded": "6",
+		"ammoCarried": "24",
+		"reloadType": "Clip\n  ",
+		"qualities": ["Unique", "Genuine", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Revolver",
+				"variant": "level"
+			},
+			{
+				"text": "Gives one guaranteed critical hit for each\nbuilding destroyed with your sapper attached\nor backstab kill",
+				"variant": "positive"
+			},
+			{
+				"text": "-15% damage penalty",
+				"variant": "negative"
+			},
+			{
+				"text": "No random critical hits",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Knife",
+		"link": "/wiki/Knife",
+		"image": "/w/images/thumb/5/57/Item_icon_Knife.png/100px-Item_icon_Knife.png",
+		"killIcon": "/w/images/2/24/Killicon_knife.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Spy"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Normal", "Unique", "Strange", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 Knife",
+				"variant": "level"
+			},
+			{
+				"text": "Attack an enemy from behind to Backstab them for a one hit kill.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Sharp Dresser",
+		"link": "/wiki/Sharp_Dresser",
+		"image": "/w/images/thumb/e/eb/Item_icon_Sharp_Dresser.png/100px-Item_icon_Sharp_Dresser.png",
+		"killIcon": "/w/images/c/ca/Killicon_sharp_dresser.png",
+		"releaseDate": "November 23, 2011 Patch",
+		"usedBy": ["Spy"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Genuine"],
+		"attributes": [
+			{
+				"text": "Level 1 Knife",
+				"variant": "level"
+			},
+			{
+				"text": "Every merc's crazy for a sharp-dressed man. With 15th century murder-knives extruding from his cufflinks.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Black Rose",
+		"link": "/wiki/Black_Rose",
+		"image": "/w/images/thumb/3/33/Item_icon_Black_Rose.png/100px-Item_icon_Black_Rose.png",
+		"killIcon": "/w/images/6/67/Killicon_black_rose.png",
+		"releaseDate": "February 14, 2012 Patch",
+		"usedBy": ["Spy"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique"],
+		"attributes": [
+			{
+				"text": "Level 1 Knife",
+				"variant": "level"
+			},
+			{
+				"text": "Slay it with flowers.",
+				"variant": "neutral"
+			},
+			{
+				"text": "( Achievement Item: Not Tradable or Marketable )",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Your Eternal Reward",
+		"link": "/wiki/Your_Eternal_Reward",
+		"image": "/w/images/thumb/d/d3/Item_icon_Your_Eternal_Reward.png/100px-Item_icon_Your_Eternal_Reward.png",
+		"killIcon": "/w/images/6/6f/Killicon_your_eternal_reward.png",
+		"releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
+		"usedBy": ["Spy"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 Knife",
+				"variant": "level"
+			},
+			{
+				"text": "Upon a successful backstab against a human target, you rapidly disguise as your victim",
+				"variant": "positive"
+			},
+			{
+				"text": "Silent Killer: No attack noise from backstabs",
+				"variant": "positive"
+			},
+			{
+				"text": "+33% cloak drain rate",
+				"variant": "negative"
+			},
+			{
+				"text": "Normal disguises require (and consume) a full cloak meter",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Wanga Prick",
+		"link": "/wiki/Wanga_Prick",
+		"image": "/w/images/thumb/f/f5/Item_icon_Wanga_Prick.png/100px-Item_icon_Wanga_Prick.png",
+		"killIcon": "/w/images/9/97/Killicon_wanga_prick.png",
+		"releaseDate": "October 27, 2011 Patch(Very Scary Halloween Special)",
+		"usedBy": ["Spy"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Knife",
+				"variant": "level"
+			},
+			{
+				"text": "Upon a successful backstab against a human target, you rapidly disguise as your victim",
+				"variant": "positive"
+			},
+			{
+				"text": "Silent Killer: No attack noise from backstabs",
+				"variant": "positive"
+			},
+			{
+				"text": "+33% cloak drain rate",
+				"variant": "negative"
+			},
+			{
+				"text": "Normal disguises require (and consume) a full cloak meter",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Conniver's Kunai",
+		"link": "/wiki/Conniver%27s_Kunai",
+		"image": "/w/images/thumb/0/02/Item_icon_Conniver%27s_Kunai.png/100px-Item_icon_Conniver%27s_Kunai.png",
+		"killIcon": "/w/images/1/1a/Killicon_conniver%27s_kunai.png",
+		"releaseDate": "March 10, 2011 Patch(Shogun Pack)",
+		"usedBy": ["Spy"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Genuine", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 Kunai",
+				"variant": "level"
+			},
+			{
+				"text": "On Backstab: Absorbs the health from your victim",
+				"variant": "positive"
+			},
+			{
+				"text": "-55 max health on wearer",
+				"variant": "negative"
+			},
+			{
+				"text": "Start off with low health\nKill somebody with this knife\nSteal all of their health",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Big Earner",
+		"link": "/wiki/Big_Earner",
+		"image": "/w/images/thumb/c/c9/Item_icon_Big_Earner.png/100px-Item_icon_Big_Earner.png",
+		"killIcon": "/w/images/0/08/Killicon_big_earner.png",
+		"releaseDate": "June 23, 2011 Patch(\u00dcber Update)",
+		"usedBy": ["Spy"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 Knife",
+				"variant": "level"
+			},
+			{
+				"text": "+30% cloak on kill",
+				"variant": "positive"
+			},
+			{
+				"text": "Gain a speed boost on kill",
+				"variant": "positive"
+			},
+			{
+				"text": "-25 max health on wearer",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Spy-cicle",
+		"link": "/wiki/Spy-cicle",
+		"image": "/w/images/thumb/a/a3/Item_icon_Spy-cicle.png/100px-Item_icon_Spy-cicle.png",
+		"killIcon": "/w/images/8/8d/Killicon_spy-cicle.png",
+		"releaseDate": "December 15, 2011 Patch(Australian Christmas 2011)",
+		"usedBy": ["Spy"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 Knife",
+				"variant": "level"
+			},
+			{
+				"text": "On Hit by Fire: Fireproof for 1 second and Afterburn immunity for 10 seconds",
+				"variant": "positive"
+			},
+			{
+				"text": "Backstab turns victim to ice",
+				"variant": "negative"
+			},
+			{
+				"text": "Melts in fire, regenerates in 15 seconds and by picking up ammo",
+				"variant": "negative"
+			},
+			{
+				"text": "It's the perfect gift for the man who has everything: an icicle driven into their back. Even rich people can't buy that in stores.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Enthusiast's Timepiece",
+		"link": "/wiki/Enthusiast%27s_Timepiece",
+		"image": "/w/images/thumb/1/10/Item_icon_Enthusiast%27s_Timepiece.png/100px-Item_icon_Enthusiast%27s_Timepiece.png",
+		"killIcon": null,
+		"releaseDate": "November 19, 2010 Patch",
+		"usedBy": ["Spy"],
+		"slot": ["PDA 2"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique"],
+		"attributes": [
+			{
+				"text": "Level 5 Invis Watch",
+				"variant": "level"
+			},
+			{
+				"text": "Alt-Fire: Turn invisible.  Cannot attack while invisible.  Bumping in to enemies will make you slightly visible to enemies",
+				"variant": "neutral"
+			},
+			{
+				"text": "( Achievement Item: Not Tradable or Marketable )",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Qu\u00e4ckenbirdt",
+		"link": "/wiki/Qu%C3%A4ckenbirdt",
+		"image": "/w/images/thumb/f/f6/Item_icon_Quackenbirdt.png/100px-Item_icon_Quackenbirdt.png",
+		"killIcon": null,
+		"releaseDate": "November 16, 2012 Patch",
+		"usedBy": ["Spy"],
+		"slot": ["PDA 2"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Genuine"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Invis Watch",
+				"variant": "level"
+			},
+			{
+				"text": "A marvel of German engineering, the Qu\u00e4ckenbirdt is a classically handsome two-tone Australium and tungsten spywatch for the European assassin who likes to be reminded how rich he is every time he turns invisible.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Cloak and Dagger",
+		"link": "/wiki/Cloak_and_Dagger",
+		"image": "/w/images/thumb/0/00/Item_icon_Cloak_and_Dagger.png/100px-Item_icon_Cloak_and_Dagger.png",
+		"killIcon": null,
+		"releaseDate": "May 21, 2009 Patch(Sniper vs. Spy Update)",
+		"usedBy": ["Spy"],
+		"slot": ["PDA 2"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Invis Watch",
+				"variant": "level"
+			},
+			{
+				"text": " Cloak Type: Motion Sensitive.\nAlt-Fire: Turn invisible.  Cannot attack while invisible.  Bumping in to enemies will make you slightly visible to enemies.\nCloak drain rate based on movement speed. ",
+				"variant": "neutral"
+			},
+			{
+				"text": "+100% cloak regen rate",
+				"variant": "positive"
+			},
+			{
+				"text": "No cloak meter from ammo boxes when invisible",
+				"variant": "negative"
+			},
+			{
+				"text": "-35% cloak meter from ammo boxes",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Dead Ringer",
+		"link": "/wiki/Dead_Ringer",
+		"image": "/w/images/thumb/b/b7/Item_icon_Dead_Ringer.png/100px-Item_icon_Dead_Ringer.png",
+		"killIcon": null,
+		"releaseDate": "May 21, 2009 Patch(Sniper vs. Spy Update)",
+		"usedBy": ["Spy"],
+		"slot": ["PDA 2"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Vintage", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Invis Watch",
+				"variant": "level"
+			},
+			{
+				"text": " Cloak Type: Feign Death.\nLeave a fake corpse on taking damage\nand temporarily gain invisibility, speed and damage resistance. ",
+				"variant": "neutral"
+			},
+			{
+				"text": "+50% cloak regen rate",
+				"variant": "positive"
+			},
+			{
+				"text": "+40% cloak duration",
+				"variant": "positive"
+			},
+			{
+				"text": "-50% cloak meter when Feign Death is activated",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Sapper",
+		"link": "/wiki/Sapper",
+		"image": "/w/images/thumb/6/6c/Item_icon_Sapper.png/100px-Item_icon_Sapper.png",
+		"killIcon": "/w/images/6/6a/Killicon_electro_sapper.png",
+		"releaseDate": "unknown",
+		"usedBy": ["Spy"],
+		"slot": ["Building"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Normal", "Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "Level 1 Sapper",
+				"variant": "level"
+			},
+			{
+				"text": "Place on enemy buildings to disable and slowly drain away its health.  Placing a sapper does not remove your disguise",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Ap-Sap",
+		"link": "/wiki/Ap-Sap",
+		"image": "/w/images/thumb/1/17/Item_icon_Ap-Sap.png/100px-Item_icon_Ap-Sap.png",
+		"killIcon": "/w/images/9/92/Killicon_ap-sap.png",
+		"releaseDate": "March 12, 2013 Patch",
+		"usedBy": ["Spy"],
+		"slot": ["Building"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Genuine"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Sapper",
+				"variant": "level"
+			},
+			{
+				"text": "Mann Co. got a great deal from a nice lady in an abandoned science facility on a warehouse full of slightly used, possibly mildly defective sappers. Unlike our other sappers, the ___ is sentient, and will provide hours of lively, one-sided conversation while you're trying to work.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Snack Attack",
+		"link": "/wiki/Snack_Attack",
+		"image": "/w/images/thumb/2/27/Item_icon_Snack_Attack.png/100px-Item_icon_Snack_Attack.png",
+		"killIcon": "/w/images/b/bf/Killicon_snack_attack.png",
+		"releaseDate": "June 18, 2014 Patch(Love & War Update)",
+		"usedBy": ["Spy"],
+		"slot": ["Building"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "Inspired by the TF2 Movie 'Expiration Date'",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Red-Tape Recorder",
+		"link": "/wiki/Red-Tape_Recorder",
+		"image": "/w/images/thumb/7/7d/Item_icon_Red-Tape_Recorder.png/100px-Item_icon_Red-Tape_Recorder.png",
+		"killIcon": "/w/images/f/ff/Killicon_red-tape_recorder.png",
+		"releaseDate": "August 2, 2012 Patch(Triad Pack)",
+		"usedBy": ["Spy"],
+		"slot": ["Building"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Genuine", "Strange", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Sapper",
+				"variant": "level"
+			},
+			{
+				"text": "Reverses enemy building construction",
+				"variant": "positive"
+			},
+			{
+				"text": "-100% sapper damage penalty",
+				"variant": "negative"
+			}
+		]
+	},
+	{
+		"name": "Saxxy",
+		"link": "/wiki/Saxxy",
+		"image": "/w/images/thumb/1/18/Item_icon_Saxxy.png/100px-Item_icon_Saxxy.png",
+		"killIcon": "/w/images/e/ea/Killicon_saxxy.png",
+		"releaseDate": "June 8, 2011 Patch",
+		"usedBy": ["All classes"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Strange"],
+		"attributes": [
+			{
+				"text": "Strange Award - Kills: 0",
+				"variant": "level"
+			},
+			{
+				"text": "Winner: [Category] [Year]",
+				"variant": "positive"
+			},
+			{
+				"text": "Imbued with an ancient power",
+				"variant": "positive"
+			},
+			{
+				"text": "( Not Tradable or Marketable )",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Frying Pan",
+		"link": "/wiki/Frying_Pan",
+		"image": "/w/images/thumb/c/c1/Item_icon_Frying_Pan.png/100px-Item_icon_Frying_Pan.png",
+		"killIcon": "/w/images/6/61/Killicon_frying_pan.png",
+		"releaseDate": "September 30, 2010 Patch(Mann-Conomy Update)",
+		"usedBy": ["All classes (except Engineer and Spy)"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "Level 5 Frying Pan",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Conscientious Objector",
+		"link": "/wiki/Conscientious_Objector",
+		"image": "/w/images/thumb/c/cb/Item_icon_Conscientious_Objector.png/100px-Item_icon_Conscientious_Objector.png",
+		"killIcon": "/w/images/4/4b/Killicon_conscientious_objector.png",
+		"releaseDate": "October 13, 2011 Patch(Manniversary Update & Sale)",
+		"usedBy": ["All classes (except Engineer and Spy)"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 25 Sign",
+				"variant": "level"
+			},
+			{
+				"text": "We gave peace a chance. It didn't work.\n\nCustom decals can be applied to this item.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Freedom Staff",
+		"link": "/wiki/Freedom_Staff",
+		"image": "/w/images/thumb/2/28/Item_icon_Freedom_Staff.png/100px-Item_icon_Freedom_Staff.png",
+		"killIcon": "/w/images/3/35/Killicon_freedom_staff.png",
+		"releaseDate": "September 27, 2012 Patch",
+		"usedBy": ["All classes (except Engineer and Spy)"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Genuine"],
+		"attributes": [
+			{
+				"text": "Level 25 Staff",
+				"variant": "level"
+			},
+			{
+				"text": "Since America was founded over ten thousand years ago, the noble eagle has been its symbol of freedom. Show people how much you like freedom by clubbing them senseless with a golden eagle on a stick, just like Kofi Annan.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Bat Outta Hell",
+		"link": "/wiki/Bat_Outta_Hell",
+		"image": "/w/images/thumb/c/c5/Item_icon_Bat_Outta_Hell.png/100px-Item_icon_Bat_Outta_Hell.png",
+		"killIcon": "/w/images/7/74/Killicon_bat_outta_hell.png",
+		"releaseDate": "October 26, 2012 Patch(Spectral Halloween Special)",
+		"usedBy": ["All classes (except Engineer and Spy)"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Haunted", "Collector's"],
+		"attributes": [
+			{
+				"text": "Level 5 Skull Bat",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Memory Maker",
+		"link": "/wiki/Memory_Maker",
+		"image": "/w/images/thumb/9/93/Item_icon_Memory_Maker.png/100px-Item_icon_Memory_Maker.png",
+		"killIcon": "/w/images/1/10/Killicon_memory_maker.png",
+		"releaseDate": "November 29, 2012 Patch",
+		"usedBy": ["All classes (except Engineer and Spy)"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Strange"],
+		"attributes": [
+			{
+				"text": "Strange Camera - Kills: 0",
+				"variant": "level"
+			},
+			{
+				"text": "Saxxy Nominee: [Category] [Year]",
+				"variant": "positive"
+			},
+			{
+				"text": "The memories you made as a Saxxy finalist will live on forever in film. Other memories\u2014like that time you fractured some jerk Engineer's skull with an 8mm camera\u2014will live on forever in your heart.",
+				"variant": "neutral"
+			},
+			{
+				"text": "( Not Tradable or Marketable )",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Ham Shank",
+		"link": "/wiki/Ham_Shank",
+		"image": "/w/images/thumb/6/6a/Item_icon_Ham_Shank.png/100px-Item_icon_Ham_Shank.png",
+		"killIcon": "/w/images/c/ca/Killicon_ham_shank.png",
+		"releaseDate": "March 12, 2013 Patch",
+		"usedBy": ["All classes (except Engineer and Spy)"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Genuine"],
+		"attributes": [
+			{
+				"text": "Level 5 Pork Product",
+				"variant": "level"
+			},
+			{
+				"text": "This makeshift classic is a prison staple. Simply take any common, everyday prison item, like a toothbrush or ham, whittle it to a point, and use it to shiv snitches waiting in line at the commissary for a second helping of ham and toothbrushes.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Golden Frying Pan",
+		"link": "/wiki/Golden_Frying_Pan",
+		"image": "/w/images/thumb/8/8f/Item_icon_Golden_Frying_Pan.png/100px-Item_icon_Golden_Frying_Pan.png",
+		"killIcon": "/w/images/c/cb/Killicon_golden_frying_pan.png",
+		"releaseDate": "November 21, 2013 Patch(Two Cities Update)",
+		"usedBy": ["All classes"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Strange"],
+		"attributes": [
+			{
+				"text": "Strange Golden Frying Pan - Kills: 0",
+				"variant": "level"
+			},
+			{
+				"text": "Imbued with an ancient power",
+				"variant": "positive"
+			},
+			{
+				"text": "Killstreaker: [Effect]",
+				"variant": "positive"
+			},
+			{
+				"text": "Sheen: [Color]",
+				"variant": "positive"
+			},
+			{
+				"text": "Killstreaks Active",
+				"variant": "positive"
+			}
+		]
+	},
+	{
+		"name": "Necro Smasher",
+		"link": "/wiki/Necro_Smasher",
+		"image": "/w/images/thumb/1/1a/Item_icon_Necro_Smasher.png/100px-Item_icon_Necro_Smasher.png",
+		"killIcon": "/w/images/9/97/Killicon_necro_smasher.png",
+		"releaseDate": "October 29, 2014 Patch(Scream Fortress VI)",
+		"usedBy": ["All classes (except Spy)"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "Level 50 Hammer",
+				"variant": "level"
+			},
+			{
+				"text": "( Achievement Item: Not Tradable or Marketable )",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Crossing Guard",
+		"link": "/wiki/Crossing_Guard",
+		"image": "/w/images/thumb/8/8c/Item_icon_Crossing_Guard.png/100px-Item_icon_Crossing_Guard.png",
+		"killIcon": "/w/images/8/80/Killicon_crossing_guard.png",
+		"releaseDate": "December 8, 2014 Patch(End of the Line Update)",
+		"usedBy": ["All classes (except Engineer and Spy)"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Strange"],
+		"attributes": [
+			{
+				"text": "Level 25 Sign",
+				"variant": "level"
+			}
+		]
+	},
+	{
+		"name": "Prinny Machete",
+		"link": "/wiki/Prinny_Machete",
+		"image": "/w/images/thumb/e/ef/Item_icon_Prinny_Machete.png/100px-Item_icon_Prinny_Machete.png",
+		"killIcon": "/w/images/b/bc/Killicon_prinny_machete.png",
+		"releaseDate": "July 7, 2016 Patch(Meet Your Match Update)",
+		"usedBy": ["All classes"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique", "Genuine"],
+		"attributes": [
+			{
+				"text": "Level 5 Machete",
+				"variant": "level"
+			},
+			{
+				"text": "( Not Usable in Crafting )",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Dragon's Fury",
+		"link": "/wiki/Dragon%27s_Fury",
+		"image": "/w/images/thumb/1/1f/Item_icon_Dragon%27s_Fury.png/75px-Item_icon_Dragon%27s_Fury.png",
+		"killIcon": "/w/images/2/20/Killicon_dragon%27s_fury.png",
+		"releaseDate": "October 20, 2017 Patch(Jungle Inferno Update)",
+		"usedBy": ["Pyro"],
+		"slot": ["Primary"],
+		"ammoLoaded": 40,
+		"ammoCarried": null,
+		"reloadType": "No reload\n  ",
+		"qualities": ["Unique", "Decorated"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Flame Launcher",
+				"variant": "level"
+			},
+			{
+				"text": "Uses a shared pressure tank for Primary\nFire and Alt-Fire.",
+				"variant": "neutral"
+			},
+			{
+				"text": "Primary Fire: Launches a fast-moving\nprojectile that briefly ignites enemies",
+				"variant": "neutral"
+			},
+			{
+				"text": "Alt-Fire: Release a blast of air that\npushes enemies and projectiles, and\nextinguishes teammates that are on fire.",
+				"variant": "neutral"
+			},
+			{
+				"text": "Extinguishing teammates restores 20\nhealth",
+				"variant": "positive"
+			},
+			{
+				"text": "Deals 300% damage to burning players\n+50% re-pressurization rate on hit",
+				"variant": "positive"
+			},
+			{
+				"text": "-50% repressurization rate on Alt-Fire",
+				"variant": "negative"
+			},
+			{
+				"text": "This powerful, single-shot flamethrower\nrewards consecutive hits with faster\nreloads and bonus damage.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Gas Passer",
+		"link": "/wiki/Gas_Passer",
+		"image": "/w/images/thumb/1/1f/Item_icon_Dragon%27s_Fury.png/75px-Item_icon_Dragon%27s_Fury.png",
+		"killIcon": null,
+		"releaseDate": "October 20, 2017 Patch(Jungle Inferno Update)",
+		"usedBy": ["Pyro"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "Recharge (60 seconds max)\n  ",
+		"qualities": ["Unique"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Gas-Like Substance",
+				"variant": "level"
+			},
+			{
+				"text": "Gas meter builds with damage done\nand/or time",
+				"variant": "positive"
+			},
+			{
+				"text": "Spawning and resupply do not affect\nthe Gas meter\nGas meter starts empty",
+				"variant": "negative"
+			},
+			{
+				"text": "Creates a horrific visible gas cloud that\ncoats enemies with a flammable\nmaterial, which then ignites into\nafterburn if they take damage (even\nenemy Pyros!)",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Hot Hand",
+		"link": "/wiki/Hot_Hand",
+		"image": "/w/images/thumb/f/f6/Item_icon_Hot_Hand.png/75px-Item_icon_Hot_Hand.png",
+		"killIcon": "/w/images/8/8a/Killicon_hot_hand.png",
+		"releaseDate": "October 20, 2017 Patch(Jungle Inferno Update)",
+		"usedBy": ["Pyro"],
+		"slot": ["Melee"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": null,
+		"qualities": ["Unique"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Slap",
+				"variant": "level"
+			},
+			{
+				"text": "Gain a speed boost when you hit an\nenemy player",
+				"variant": "positive"
+			},
+			{
+				"text": "-20% damage penalty",
+				"variant": "negaitve"
+			},
+			{
+				"text": "This melee slap tells your opponent, and\nanyone watching the kill feed, that your\nhand just gave some lucky face the gift of\nslapping it stupid.",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Thermal Thruster",
+		"link": "/wiki/Thermal_Thruster",
+		"image": "/w/images/thumb/0/00/Item_icon_Thermal_Thruster.png/75px-Item_icon_Thermal_Thruster.png",
+		"killIcon": "/w/images/a/ac/Killicon_mantreads.png",
+		"releaseDate": "October 20, 2017 Patch(Jungle Inferno Update)",
+		"usedBy": ["Pyro"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "Recharge (15 Seconds per charge)\n  ",
+		"qualities": ["Unique"],
+		"attributes": [
+			{
+				"text": "Level 1 - 100 Rocket Pack",
+				"variant": "level"
+			},
+			{
+				"text": "Push enemies back when you land\n(force and radius based on velocity)",
+				"variant": "neutral"
+			},
+			{
+				"text": "Death from above! Fires a short-duration\nblast that launches the Pyro in the\ndirection they are aiming. Deal 3x falling\ndamage to anyone you land on!",
+				"variant": "neutral"
+			}
+		]
+	},
+	{
+		"name": "Second Banana",
+		"link": "/wiki/Second_Banana",
+		"image": "/w/images/thumb/7/77/Item_icon_Second_Banana.png/75px-Item_icon_Second_Banana.png",
+		"killIcon": null,
+		"releaseDate": "October 20, 2017 Patch(Jungle Inferno Update)",
+		"usedBy": ["Heavy"],
+		"slot": ["Secondary"],
+		"ammoLoaded": null,
+		"ammoCarried": null,
+		"reloadType": "Recharge (10 Seconds)\n  ",
+		"qualities": ["Unique"],
+		"attributes": [
+			{
+				"text": "Level 1 Lunch Box",
+				"variant": "level"
+			},
+			{
+				"text": "+50% increase in charge recharge rate",
+				"variant": "positive"
+			},
+			{
+				"text": "-33% healing effect",
+				"variant": "negative"
+			},
+			{
+				"text": "Eat to gain up to 100 health.\nAlt-fire: Share chocolate with a friend (Small\nHealth Kit)",
+				"variant": "neutral"
+			}
+		]
+	}
 ]

--- a/src/lib/server/services/CosmeticService.ts
+++ b/src/lib/server/services/CosmeticService.ts
@@ -5,6 +5,7 @@ import { cosmeticRepository } from '$lib/server/repositories/CosmeticRepositoryP
 import LogService from './LogService';
 import dayjs from '$lib/configs/dayjsConfig';
 import type { Dayjs } from 'dayjs';
+import { generateRandomInteger } from 'oslo/crypto';
 
 /**
  * Service for handling cosmetics
@@ -46,8 +47,8 @@ class CosmeticService {
 	 * @returns the selected cosmetic
 	 */
 	private async selectRandomCosmetic() {
-		const randomIndex = Math.floor(Math.random() * this.cosmetics.length);
-		const randomRotation = Math.floor(Math.random() * 4) * 90;
+		const randomIndex = generateRandomInteger(this.cosmetics.length);
+		const randomRotation = generateRandomInteger(4) * 90;
 
 		LogService.log(
 			'Cosmetic',

--- a/src/lib/server/services/MapService.ts
+++ b/src/lib/server/services/MapService.ts
@@ -5,6 +5,7 @@ import type { MapRepository } from '../repositories/MapRepository';
 import { mapRepository } from '../repositories/MapRepositoryPrisma';
 import LogService from './LogService';
 import type { Dayjs } from 'dayjs';
+import { generateRandomInteger } from 'oslo/crypto';
 
 class MapService {
 	private maps: Map[];
@@ -20,7 +21,7 @@ class MapService {
 	 */
 	public async selectRandomMap() {
 		// Select a random map
-		const map = this.maps[Math.floor(Math.random() * this.maps.length)];
+		const map = this.maps[generateRandomInteger(this.maps.length)];
 
 		// Select a random starting position for the image
 		const startingPos = {

--- a/src/lib/server/services/UnusualService.ts
+++ b/src/lib/server/services/UnusualService.ts
@@ -5,6 +5,7 @@ import { unusualRepository } from '../repositories/UnusualRepositoryPrisma';
 import type { Dayjs } from 'dayjs';
 import LogService from './LogService';
 import dayjs from '$lib/configs/dayjsConfig';
+import { generateRandomInteger } from 'oslo/crypto';
 
 class UnusualService {
 	private unusuals: Unusual[];
@@ -44,8 +45,8 @@ class UnusualService {
 	 * @return the selected unusual
 	 */
 	private async selectRandomUnusual() {
-		const randomIndex = Math.floor(Math.random() * this.unusuals.length);
-		const randomRotation = Math.floor(Math.random() * 4) * 90;
+		const randomIndex = generateRandomInteger(this.unusuals.length);
+		const randomRotation = generateRandomInteger(4) * 90;
 
 		LogService.log(
 			'Unusual',

--- a/src/lib/server/services/WeaponService.ts
+++ b/src/lib/server/services/WeaponService.ts
@@ -5,6 +5,7 @@ import type { WeaponRepository } from '$lib/server/repositories/WeaponRepository
 import LogService from './LogService';
 import dayjs from '$lib/configs/dayjsConfig';
 import type { Dayjs } from 'dayjs';
+import { generateRandomInteger } from 'oslo/crypto';
 
 class WeaponService {
 	private weapons: Weapon[];
@@ -202,7 +203,7 @@ class WeaponService {
 	 * @returns the name of the selected weapon
 	 */
 	public async selectNewRandomWeapon() {
-		const weapon = this.weapons[Math.floor(Math.random() * this.weapons.length)];
+		const weapon = this.weapons[generateRandomInteger(this.weapons.length)];
 
 		await this.repo.save(weapon);
 

--- a/src/lib/server/services/WeaponTwoService.ts
+++ b/src/lib/server/services/WeaponTwoService.ts
@@ -5,6 +5,7 @@ import type { WeaponTwoRepository } from '../repositories/WeaponTwoRepository';
 import type { Dayjs } from 'dayjs';
 import LogService from './LogService';
 import dayjs from '$lib/configs/dayjsConfig';
+import { generateRandomInteger } from 'oslo/crypto';
 
 class WeaponTwoService {
 	private weapons: Weapon[];
@@ -41,7 +42,7 @@ class WeaponTwoService {
 	 * @returns the selected weapon
 	 */
 	private async selectRandomWeapon() {
-		const randomIndex = Math.floor(Math.random() * this.weapons.length);
+		const randomIndex = generateRandomInteger(this.weapons.length);
 
 		const selectedWeapon = this.weapons[randomIndex];
 

--- a/src/routes/patch-notes/+page.svelte
+++ b/src/routes/patch-notes/+page.svelte
@@ -2,6 +2,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import patchNotes, { lastViewedPatchNote } from '$lib/patchNotes';
 	import { onMount } from 'svelte';
+	import PatchNoteItem from './patch-note-item.svelte';
 
 	onMount(() => {
 		lastViewedPatchNote.set(patchNotes[0].version);
@@ -9,7 +10,7 @@
 </script>
 
 {#each patchNotes as patch}
-	<Card.Root class="mb-4">
+	<Card.Root class="mb-4" id={patch.version}>
 		<Card.Header>
 			<div class="border-b-2 pb-4">
 				<Card.Title class="text-2xl">Patch {patch.version}</Card.Title>
@@ -21,41 +22,19 @@
 			{#if patch.newFeatures.length > 0}
 				<h3 class="text-sm text-primary font-semibold mb-2">New Features</h3>
 				{#each patch.newFeatures as feature}
-					{@const gameModes =
-						feature.gameMode instanceof Array ? feature.gameMode.join(', ') : feature.gameMode}
-					<article class="mb-6">
-						<h4 class="font-semibold mb-2">{feature.title}</h4>
-						<p class="text-sm mb-2 leading-6">{@html feature.description}</p>
-						<p class="text-sm text-muted-foreground">Game modes: {gameModes}</p>
-					</article>
+					<PatchNoteItem item={feature} />
 				{/each}
 			{/if}
 			{#if patch.improvements.length > 0}
 				<h3 class="text-sm text-primary font-semibold mb-2">Improvements</h3>
 				{#each patch.improvements as improvement}
-					{@const gameModes =
-						improvement.gameMode instanceof Array
-							? improvement.gameMode.join(', ')
-							: improvement.gameMode}
-
-					<article class="mb-6">
-						<h4 class="font-semibold mb-2">{improvement.title}</h4>
-						<p class="text-sm mb-2 leading-6">{@html improvement.description}</p>
-						<p class="text-sm text-muted-foreground">Game modes: {gameModes}</p>
-					</article>
+					<PatchNoteItem item={improvement} />
 				{/each}
 			{/if}
 			{#if patch.bugFixes.length > 0}
 				<h3 class="text-sm text-primary font-semibold mb-2">Bug fixes</h3>
 				{#each patch.bugFixes as fix}
-					{@const gameModes =
-						fix.gameMode instanceof Array ? fix.gameMode.join(', ') : fix.gameMode}
-
-					<article class="mb-6">
-						<h4 class="font-semibold mb-2">{fix.title}</h4>
-						<p class="text-sm mb-2 leading-6">{@html fix.description}</p>
-						<p class="text-sm text-muted-foreground">Game modes: {gameModes}</p>
-					</article>
+					<PatchNoteItem item={fix} />
 				{/each}
 			{/if}
 		</Card.Content>

--- a/src/routes/patch-notes/patch-note-item.svelte
+++ b/src/routes/patch-notes/patch-note-item.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import type { Change } from '$lib/patchNotes/types';
+
+	export let item: Change;
+</script>
+
+<article class="mb-6">
+	<h4 class="font-semibold mb-2">{item.title}</h4>
+	<p class="text-sm leading-6">{@html item.description}</p>
+	{#if item.reportedBy}
+		<p class="text-sm text-muted-foreground mt-2">
+			Reported by:
+			<a href={item.reportedBy.user.link} class="patch-link">{item.reportedBy.user.name}</a>
+			-
+			{item.reportedBy.note}
+		</p>
+	{/if}
+	<div class="flex gap-1 mt-4">
+		{#if item.gameMode instanceof Array}
+			{#each item.gameMode as mode}
+				<p class="text-xs bg-muted rounded-full w-fit px-3 py-1 text-muted-foreground">{mode}</p>
+			{/each}
+		{:else}
+			<p class="text-xs bg-muted rounded-full w-fit px-3 py-1 text-muted-foreground">
+				{item.gameMode}
+			</p>
+		{/if}
+	</div>
+</article>


### PR DESCRIPTION
This merge implements:

- Replace name in weapon 2 hints with _ to hide the name
- Updates the daily random selector from Math.random to function from oslo/crypto
- Updates the patch notes design, including a "Reported by" section